### PR TITLE
Avoid useless data-element values

### DIFF
--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -5,11 +5,8 @@ exports[`arrow snapshot matches 1`] = `
 
 const componentName = () => {
   return /*#__PURE__*/React.createElement(\\"div\\", {
-    \\"data-element\\": \\"div\\",
     \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", {
-    \\"data-element\\": \\"h1\\"
-  }, \\"Hello world\\"));
+  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -42,9 +39,7 @@ const componentName = () => {
   return /*#__PURE__*/React.createElement(Fragment, {
     \\"data-element\\": \\"Fragment\\",
     \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", {
-    \\"data-element\\": \\"h1\\"
-  }, \\"Hello world\\"));
+  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -54,11 +49,8 @@ exports[`arrow-noreturn snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
 const componentName = () => /*#__PURE__*/React.createElement(\\"div\\", {
-  \\"data-element\\": \\"div\\",
   \\"data-component\\": \\"componentName\\"
-}, /*#__PURE__*/React.createElement(\\"h1\\", {
-  \\"data-element\\": \\"h1\\"
-}, \\"Hello world\\"));
+}, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 
 export default componentName;"
 `;
@@ -70,9 +62,7 @@ const componentName = () => /*#__PURE__*/React.createElement(Fragment, {
   \\"data-element\\": \\"Fragment\\",
   \\"data-component\\": \\"componentName\\",
   \\"data-source-file\\": \\"filename-test.js\\"
-}, /*#__PURE__*/React.createElement(\\"h1\\", {
-  \\"data-element\\": \\"h1\\"
-}, \\"Hello world\\"));
+}, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 
 export default componentName;"
 `;
@@ -83,9 +73,7 @@ exports[`arrow-noreturn-react-fragment snapshot matches 1`] = `
 const componentName = () => /*#__PURE__*/React.createElement(React.Fragment, {
   \\"data-element\\": \\"unknown\\",
   \\"data-component\\": \\"componentName\\"
-}, /*#__PURE__*/React.createElement(\\"h1\\", {
-  \\"data-element\\": \\"h1\\"
-}, \\"Hello world\\"));
+}, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 
 export default componentName;"
 `;
@@ -97,9 +85,7 @@ const componentName = () => {
   return /*#__PURE__*/React.createElement(React.Fragment, {
     \\"data-element\\": \\"unknown\\",
     \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", {
-    \\"data-element\\": \\"h1\\"
-  }, \\"Hello world\\"));
+  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -111,11 +97,8 @@ exports[`component snapshot matches 1`] = `
 class componentName extends Component {
   render() {
     return /*#__PURE__*/React.createElement(\\"div\\", {
-      \\"data-element\\": \\"div\\",
       \\"data-component\\": \\"componentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", {
-      \\"data-element\\": \\"h1\\"
-    }, \\"Hello world\\"));
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -191,11 +174,8 @@ exports[`option-attribute snapshot matches 1`] = `
 
 const componentName = () => {
   return /*#__PURE__*/React.createElement(\\"div\\", {
-    \\"data-element\\": \\"div\\",
     \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", {
-    \\"data-element\\": \\"h1\\"
-  }, \\"Hello world\\"));
+  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -206,11 +186,8 @@ exports[`option-format snapshot matches 1`] = `
 
 const componentName = () => {
   return /*#__PURE__*/React.createElement(\\"div\\", {
-    \\"data-element\\": \\"div\\",
     \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", {
-    \\"data-element\\": \\"h1\\"
-  }, \\"Hello world\\"));
+  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -222,11 +199,8 @@ exports[`pure snapshot matches 1`] = `
 class PureComponentName extends React.PureComponent {
   render() {
     return /*#__PURE__*/React.createElement(\\"div\\", {
-      \\"data-element\\": \\"div\\",
       \\"data-component\\": \\"PureComponentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", {
-      \\"data-element\\": \\"h1\\"
-    }, \\"Hello world\\"));
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -240,12 +214,9 @@ exports[`pure-native snapshot matches 1`] = `
 class PureComponentName extends React.PureComponent {
   render() {
     return /*#__PURE__*/React.createElement(\\"div\\", {
-      dataElement: \\"div\\",
       dataComponent: \\"PureComponentName\\",
       dataSourceFile: \\"filename-test.js\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", {
-      dataElement: \\"h1\\"
-    }, \\"Hello world\\"));
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -261,9 +232,7 @@ class PureComponentName extends React.PureComponent {
     return /*#__PURE__*/React.createElement(Fragment, {
       \\"data-element\\": \\"Fragment\\",
       \\"data-component\\": \\"PureComponentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", {
-      \\"data-element\\": \\"h1\\"
-    }, \\"Hello world\\"));
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -279,9 +248,7 @@ class PureComponentName extends React.PureComponent {
     return /*#__PURE__*/React.createElement(React.Fragment, {
       \\"data-element\\": \\"unknown\\",
       \\"data-component\\": \\"PureComponentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", {
-      \\"data-element\\": \\"h1\\"
-    }, \\"Hello world\\"));
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -294,14 +261,12 @@ exports[`rawfunction snapshot matches 1`] = `
 
 function SubComponent() {
   return /*#__PURE__*/React.createElement(\\"div\\", {
-    \\"data-element\\": \\"div\\",
     \\"data-component\\": \\"SubComponent\\"
   }, \\"Sub\\");
 }
 
 const componentName = () => {
   return /*#__PURE__*/React.createElement(\\"div\\", {
-    \\"data-element\\": \\"div\\",
     \\"data-component\\": \\"componentName\\"
   }, /*#__PURE__*/React.createElement(SubCoponent, {
     \\"data-element\\": \\"SubCoponent\\"
@@ -448,4 +413,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center'
   }
 });"
+`;
+
+exports[`unknown-element snapshot matches 1`] = `
+"import React, { Component } from 'react';
+
+class componentName extends Component {
+  render() {
+    return /*#__PURE__*/React.createElement(\\"bogus\\", {
+      \\"data-element\\": \\"bogus\\",
+      \\"data-component\\": \\"componentName\\",
+      \\"data-source-file\\": \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"A\\"));
+  }
+
+}
+
+export default componentName;"
 `;

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2,6 +2,27 @@ const babel = require('babel-core');
 const plugin = require('../');
 const assert = require('assert');
 
+it('unknown-element snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+
+class componentName extends Component {
+  render() {
+    return <bogus><h1>A</h1></bogus>;
+  }
+}
+
+export default componentName;
+`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [plugin]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
 it('component-fragment snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component, Fragment } from 'react';

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
     return node.name.name === elementAttributeName
   }) == null){
     const name = openingElement.node.name.name || 'unknown'
-    if (ignoredElements.indexOf(name) === -1) {
+    if (ignoredElements.includes(name) === false) {
       openingElement.node.attributes.push(
         t.jSXAttribute(
           t.jSXIdentifier(elementAttributeName),

--- a/index.js
+++ b/index.js
@@ -106,12 +106,15 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
     if (!node.name) return
     return node.name.name === elementAttributeName
   }) == null){
-    openingElement.node.attributes.push(
-      t.jSXAttribute(
-        t.jSXIdentifier(elementAttributeName),
-        t.stringLiteral(openingElement.node.name.name || 'unknown')
+    const name = openingElement.node.name.name || 'unknown'
+    if (ignoredElements.indexOf(name) === -1) {
+      openingElement.node.attributes.push(
+        t.jSXAttribute(
+          t.jSXIdentifier(elementAttributeName),
+          t.stringLiteral(name)
+        )
       )
-    )
+    }
   }
 
   // Add a stable attribute for the component name (absent for non-root elements)
@@ -180,3 +183,26 @@ function functionBodyPushAttributes(t, path, componentName, sourceFileName, comp
 
   processJSXElement(t, jsxElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName)
 }
+
+// We don't write data-element attributes for these names
+const ignoredElements = [
+  'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio',
+  'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button',
+  'canvas', 'caption', 'cite', 'code', 'col', 'colgroup',
+  'data', 'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl', 'dt',
+  'em', 'embed',
+  'fieldset', 'figure', 'footer', 'form',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header', 'hgroup', 'hr', 'html',
+  'i', 'iframe', 'img', 'input', 'ins',
+  'kbd', 'keygen',
+  'label', 'legend', 'li', 'link',
+  'main', 'map', 'mark', 'menu', 'menuitem', 'meter',
+  'nav', 'noscript',
+  'object', 'ol', 'optgroup', 'option', 'output',
+  'p', 'param', 'pre', 'progress', 'q', 'rb', 'rp', 'rt', 'rtc', 'ruby',
+  's', 'samp', 'script', 'section', 'select', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary', 'sup',
+  'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th', 'thead', 'time', 'title', 'tr', 'track',
+  'u', 'ul',
+  'var', 'video',
+  'wbr'
+]


### PR DESCRIPTION
This PR adds a list of element names that aren't written as data-element attributes.
This avoids useless duplication like \<h1 data-element=h1\>.

This is based on a suggestion from @chiplay