### PR TITLE
Source file on elements (not just components)

### DIFF
--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -374,13 +374,15 @@ class PizzaTranslator extends Component {
         text
       }),
       value: this.state.text,
-      dataElement: \\"TextInput\\"
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
     }), /*#__PURE__*/React.createElement(Text, {
       style: {
         padding: 10,
         fontSize: 42
       },
-      dataElement: \\"Text\\"
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
     }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
   }
 
@@ -396,11 +398,14 @@ export default function App() {
     style: {
       color: '#eee'
     },
-    dataElement: \\"Text\\"
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
   }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
-    dataElement: \\"Bananas\\"
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
   }), /*#__PURE__*/React.createElement(PizzaTranslator, {
-    dataElement: \\"PizzaTranslator\\"
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
   }));
 }
 const styles = StyleSheet.create({

--- a/index.js
+++ b/index.js
@@ -139,8 +139,8 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
     && (componentName || ignoredElement === false)
     && openingElement.node.attributes.find(node => {
       if (!node.name) return
-        return node.name.name === sourceFileAttributeName
-      }
+      return node.name.name === sourceFileAttributeName
+    }
   ) == null){
     openingElement.node.attributes.push(
       t.jSXAttribute(


### PR DESCRIPTION
Added the `data-source-file` attribute to elements with the `data-element` attribute. It was previously only on elements with `data-component`.

This makes it more useful for styled-components.

Now that we don't decorate standard DOM elements with `data-element` this is a relatively light-weight addition.

(based on suggestions from @chiplay)