### PR TITLE
fix Fragment check by not returning early

### DIFF
--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -36,10 +36,7 @@ exports[`arrow-fragment snapshot matches 1`] = `
 "import React, { Component, Fragment } from 'react';
 
 const componentName = () => {
-  return /*#__PURE__*/React.createElement(Fragment, {
-    \\"data-element\\": \\"Fragment\\",
-    \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+  return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -58,11 +55,7 @@ export default componentName;"
 exports[`arrow-noreturn-fragment snapshot matches 1`] = `
 "import React, { Component, Fragment } from 'react';
 
-const componentName = () => /*#__PURE__*/React.createElement(Fragment, {
-  \\"data-element\\": \\"Fragment\\",
-  \\"data-component\\": \\"componentName\\",
-  \\"data-source-file\\": \\"filename-test.js\\"
-}, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 
 export default componentName;"
 `;
@@ -70,10 +63,7 @@ export default componentName;"
 exports[`arrow-noreturn-react-fragment snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
-const componentName = () => /*#__PURE__*/React.createElement(React.Fragment, {
-  \\"data-element\\": \\"unknown\\",
-  \\"data-component\\": \\"componentName\\"
-}, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+const componentName = () => /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 
 export default componentName;"
 `;
@@ -82,10 +72,7 @@ exports[`arrow-react-fragment snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
 const componentName = () => {
-  return /*#__PURE__*/React.createElement(React.Fragment, {
-    \\"data-element\\": \\"unknown\\",
-    \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
 };
 
 export default componentName;"
@@ -111,11 +98,7 @@ exports[`component-fragment snapshot matches 1`] = `
 
 class componentName extends Component {
   render() {
-    return /*#__PURE__*/React.createElement(Fragment, {
-      \\"data-element\\": \\"Fragment\\",
-      \\"data-component\\": \\"componentName\\",
-      \\"data-source-file\\": \\"filename-test.js\\"
-    }, \\"A\\");
+    return /*#__PURE__*/React.createElement(Fragment, null, \\"A\\");
   }
 
 }
@@ -128,10 +111,7 @@ exports[`component-fragment-native snapshot matches 1`] = `
 
 class componentName extends Component {
   render() {
-    return /*#__PURE__*/React.createElement(Fragment, {
-      dataElement: \\"Fragment\\",
-      dataComponent: \\"componentName\\"
-    }, \\"A\\");
+    return /*#__PURE__*/React.createElement(Fragment, null, \\"A\\");
   }
 
 }
@@ -144,11 +124,7 @@ exports[`component-react-fragment snapshot matches 1`] = `
 
 class componentName extends Component {
   render() {
-    return /*#__PURE__*/React.createElement(React.Fragment, {
-      \\"data-element\\": \\"unknown\\",
-      \\"data-component\\": \\"componentName\\",
-      \\"data-source-file\\": \\"filename-test.js\\"
-    }, \\"A\\");
+    return /*#__PURE__*/React.createElement(React.Fragment, null, \\"A\\");
   }
 
 }
@@ -229,10 +205,7 @@ exports[`pureComponent-fragment snapshot matches 1`] = `
 
 class PureComponentName extends React.PureComponent {
   render() {
-    return /*#__PURE__*/React.createElement(Fragment, {
-      \\"data-element\\": \\"Fragment\\",
-      \\"data-component\\": \\"PureComponentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+    return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -245,10 +218,7 @@ exports[`pureComponent-react-fragment snapshot matches 1`] = `
 
 class PureComponentName extends React.PureComponent {
   render() {
-    return /*#__PURE__*/React.createElement(React.Fragment, {
-      \\"data-element\\": \\"unknown\\",
-      \\"data-component\\": \\"PureComponentName\\"
-    }, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
+    return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hello world\\"));
   }
 
 }
@@ -280,17 +250,11 @@ exports[`rawfunction-fragment snapshot matches 1`] = `
 "import React, { Component, Fragment } from 'react';
 
 function SubComponent() {
-  return /*#__PURE__*/React.createElement(Fragment, {
-    \\"data-element\\": \\"Fragment\\",
-    \\"data-component\\": \\"SubComponent\\"
-  }, \\"Sub\\");
+  return /*#__PURE__*/React.createElement(Fragment, null, \\"Sub\\");
 }
 
 const componentName = () => {
-  return /*#__PURE__*/React.createElement(Fragment, {
-    \\"data-element\\": \\"Fragment\\",
-    \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(SubCoponent, {
+  return /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(SubCoponent, {
     \\"data-element\\": \\"SubCoponent\\"
   }));
 };
@@ -302,17 +266,11 @@ exports[`rawfunction-react-fragment snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
 function SubComponent() {
-  return /*#__PURE__*/React.createElement(React.Fragment, {
-    \\"data-element\\": \\"unknown\\",
-    \\"data-component\\": \\"SubComponent\\"
-  }, \\"Sub\\");
+  return /*#__PURE__*/React.createElement(React.Fragment, null, \\"Sub\\");
 }
 
 const componentName = () => {
-  return /*#__PURE__*/React.createElement(React.Fragment, {
-    \\"data-element\\": \\"unknown\\",
-    \\"data-component\\": \\"componentName\\"
-  }, /*#__PURE__*/React.createElement(SubCoponent, {
+  return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement(SubCoponent, {
     \\"data-element\\": \\"SubCoponent\\"
   }));
 };

--- a/index.js
+++ b/index.js
@@ -76,18 +76,21 @@ function attributeNamesFromState(state) {
 function isReactFragment(openingElement) {
   if (
     !openingElement.node ||
-    !openingElement.node.name ||
-    !openingElement.node.name.name ||
+    !openingElement.node.name
+  ) return
+
+  if (openingElement.node.name.name === 'Fragment') return true;
+
+  if (
     !openingElement.node.name.type ||
     !openingElement.node.name.object ||
     !openingElement.node.name.property
   ) return
 
   return (
-    openingElement.node.name.name === 'Fragment' ||
-    (openingElement.node.name.type === 'JSXMemberExpression' &&
-      openingElement.node.name.object.name === 'React' &&
-      openingElement.node.name.property.name === 'Fragment')
+    openingElement.node.name.type === 'JSXMemberExpression' &&
+    openingElement.node.name.object.name === 'React' &&
+    openingElement.node.name.property.name === 'Fragment'
   )
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "babel-react-data-annotate",
+  "name": "@fullstory/babel-plugin-annotate-react",
   "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
@@ -3027,9 +3027,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "lodash.sortby": {


### PR DESCRIPTION
If name.object or name.property does not exist, the code is returning early. This causes us to fail to prevent Fragments from being skipped.

I don't have a good handle on the jest tests, so I request that someone with more knowledge add a test for this.

Also, there are many out of date packages with vulnerabilities that need updating.