### PR TITLE
Add the annotate-fragments option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ To activate React Native support you must pass in a `native` plugin option like 
       ["@fullstory/babel-plugin-annotate-react", { native: true }]
     ]
 
+
+By default, the plugin does not annotate `React.Fragment`s because they may or may not contain a child that ends up being an HTML element.
+
+An example with no child element:
+
+    const componentName = () => (
+      <Fragment>Hello, there.</Fragment>
+    );
+
+An example with child elements:
+
+    const componentName = () => (
+      <Fragment>
+        Some text
+        <h1>Hello, there.</h1> /* This one could be annotated */
+        <a href="#foo">Click me</a>
+      </Fragment>
+    );
+
+
+If you would like the plugin to attempt to annotate the first HTML element created by a Fragment (if it exists) then set the `annotate-fragments` flag:
+
+    plugins: [
+      ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
+    ]
+
 We have a few samples to demonstrate this plugin:
 
 - [Single Page App](./samples/single-page-app/)

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -52,6 +52,39 @@ const componentName = () => /*#__PURE__*/React.createElement(\\"div\\", {
 export default componentName;"
 `;
 
+exports[`arrow-noreturn-annotate-fragment snapshot matches 1`] = `
+"import React, { Component, Fragment } from 'react';
+
+const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", {
+  \\"data-component\\": \\"componentName\\",
+  \\"data-source-file\\": \\"filename-test.js\\"
+}, \\"Hello world\\"));
+
+export default componentName;"
+`;
+
+exports[`arrow-noreturn-annotate-fragment-no-whitespace snapshot matches 1`] = `
+"import React, { Component, Fragment } from 'react';
+
+const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", {
+  \\"data-component\\": \\"componentName\\",
+  \\"data-source-file\\": \\"filename-test.js\\"
+}, \\"Hello world\\"), /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hola Sol\\"));
+
+export default componentName;"
+`;
+
+exports[`arrow-noreturn-annotate-fragment-once snapshot matches 1`] = `
+"import React, { Component, Fragment } from 'react';
+
+const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, /*#__PURE__*/React.createElement(\\"h1\\", {
+  \\"data-component\\": \\"componentName\\",
+  \\"data-source-file\\": \\"filename-test.js\\"
+}, \\"Hello world\\"), /*#__PURE__*/React.createElement(\\"h1\\", null, \\"Hola Sol\\"));
+
+export default componentName;"
+`;
+
 exports[`arrow-noreturn-fragment snapshot matches 1`] = `
 "import React, { Component, Fragment } from 'react';
 

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -85,6 +85,14 @@ const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, /*#
 export default componentName;"
 `;
 
+exports[`arrow-noreturn-annotate-trivial-fragment snapshot matches 1`] = `
+"import React, { Component, Fragment } from 'react';
+
+const componentName = () => /*#__PURE__*/React.createElement(Fragment, null, \\"Hello world\\");
+
+export default componentName;"
+`;
+
 exports[`arrow-noreturn-fragment snapshot matches 1`] = `
 "import React, { Component, Fragment } from 'react';
 

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -87,6 +87,27 @@ export default componentName;
   expect(code).toMatchSnapshot();
 });
 
+it('arrow-noreturn-annotate-trivial-fragment snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component, Fragment } from 'react';
+
+const componentName = () => (
+  <Fragment>Hello world</Fragment>
+);
+
+export default componentName;
+`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { "annotate-fragments": true }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
 it('arrow-noreturn-annotate-fragment snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component, Fragment } from 'react';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -87,6 +87,75 @@ export default componentName;
   expect(code).toMatchSnapshot();
 });
 
+it('arrow-noreturn-annotate-fragment snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component, Fragment } from 'react';
+
+const componentName = () => (
+  <Fragment>
+    <h1>Hello world</h1>
+  </Fragment>
+);
+
+export default componentName;
+`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { "annotate-fragments": true }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('arrow-noreturn-annotate-fragment-once snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component, Fragment } from 'react';
+
+const componentName = () => (
+  <Fragment>
+    <h1>Hello world</h1>
+    <h1>Hola Sol</h1>
+  </Fragment>
+);
+
+export default componentName;
+`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { "annotate-fragments": true }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+
+it('arrow-noreturn-annotate-fragment-no-whitespace snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component, Fragment } from 'react';
+
+const componentName = () => (
+  <Fragment><h1>Hello world</h1><h1>Hola Sol</h1></Fragment>
+);
+
+export default componentName;
+`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { "annotate-fragments": true }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
 
 it('rawfunction-fragment snapshot matches', () => {
   const { code } = babel.transform(


### PR DESCRIPTION
Based on feedback from Issue #24 we have added the `annotate-fragments` option which will, when set to true, cause the plugin will look for the first HTML element child of a React.Fragment and annotate like it's the root of any other React component. 