### PR TITLE
Handle backslash path separators on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,16 @@ module.exports = function({ types: t }) {
 
 function sourceFileNameFromState(state) {
   const name = state.file.opts.parserOpts.sourceFileName
-  if (typeof name === 'string') return name.split('/').pop()
-  return undefined
+  if (typeof name !== 'string') {
+    return undefined
+  }
+  if (name.indexOf('/') !== -1) {
+    return name.split('/').pop()
+  } else if (name.indexOf('\\') !== -1) {
+    return name.split('\\').pop()
+  } else {
+    return name
+  }
 }
 
 function attributeNamesFromState(state) {


### PR DESCRIPTION
When constructing the component file source we were assuming UNIX-style forward slashes '/'.

This PR adds a logic branch to handle Windows-style back slashes '\'.