### PR TITLE
Sabrina/annotate skip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
       - run:
           name: Audit
           command: npm audit --audit-level=low
+      - run:
+          name: Test
+          command: npm run test
       - persist_to_workspace:
           root: .
           paths: .

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ If you would like the plugin to attempt to annotate the first HTML element creat
       ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
     ]
 
+If you would like the plugin to skip the annotation for one component, use `// fullstory-babel-plugin-annotate-react-disable-component` comment immediately after the opening tag name:
+
+```JSX
+const App = () => {
+  return (
+    <StylesProvider // fullstory-babel-plugin-annotate-react-disable-component
+      jss={jss}
+    >
+        <SomeComponent text="this is a text" />
+    </StylesProvider>
+  );
+};
+```
+
 We have a few samples to demonstrate this plugin:
 
 - [Single Page App](./samples/single-page-app/)

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ If you would like the plugin to attempt to annotate the first HTML element creat
       ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
     ]
 
-If you would like the plugin to skip the annotation for certain components, use the `ignore-components` option:
+If you would like the plugin to skip the annotation for certain components, use the `ignoreComponents` option:
 
 ```javascript
   plugins: [
       [
         '../..',
         { 
-          "ignore-components":[
+          ignoreComponents:[
             // each item must be a string array containing three items: file name, component name, element name 
             // corresponding to the values for data-source-file, data-component, data-element
             // use wild card (*) to match anything

--- a/README.md
+++ b/README.md
@@ -68,18 +68,24 @@ If you would like the plugin to attempt to annotate the first HTML element creat
       ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
     ]
 
-If you would like the plugin to skip the annotation for one component, use `// fullstory-babel-plugin-annotate-react-disable-component` comment immediately after the opening tag name:
+If you would like the plugin to skip the annotation for certain components, use the `ignore-components` option:
 
-```JSX
-const App = () => {
-  return (
-    <StylesProvider // fullstory-babel-plugin-annotate-react-disable-component
-      jss={jss}
-    >
-        <SomeComponent text="this is a text" />
-    </StylesProvider>
-  );
-};
+```javascript
+  plugins: [
+      [
+        '../..',
+        { 
+          "ignore-components":[
+            // each item must be a string array containing three items: file name, component name, element name 
+            // corresponding to the values for data-source-file, data-component, data-element
+            // use wild card (*) to match anything
+            ["myBoxComponent.jsx","MyBox","Box"],
+            ["App.jsx", "*", "ThemeProvider"], // use wild-card to match anything
+            ["App.jsx", "App", "*"], 
+          ]
+        }
+      ],
+  ]
 ```
 
 We have a few samples to demonstrate this plugin:

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -319,6 +319,55 @@ const componentName = () => {
 export default componentName;"
 `;
 
+exports[`tags blocklist no-match snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`tags dataElement blocklist excluded snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
 exports[`tags snapshot matches 1`] = `
 "import React, { Component } from 'react';
 import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -196,7 +196,56 @@ class Bananas extends Component {
 }"
 `;
 
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches1`] = `
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = `
 "import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -242,7 +291,59 @@ class Bananas extends Component {
 }"
 `;
 
-exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches1`] = `
+exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = `
 "import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -288,7 +389,7 @@ class Bananas extends Component {
 }"
 `;
 
-exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches1`] = `
+exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches 1`] = `
 "import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -304,7 +405,62 @@ class Bananas extends Component {
         height: 110,
         marginTop: 10
       },
-      fsClass: \\"test-class\\"
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
     });
   }
 

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -173,6 +173,170 @@ class componentName extends Component {
 export default componentName;"
 `;
 
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
 exports[`nonJSX snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
@@ -317,55 +481,6 @@ const componentName = () => {
 };
 
 export default componentName;"
-`;
-
-exports[`tags blocklist no-match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`tags dataElement blocklist excluded snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
-
-}"
 `;
 
 exports[`tags snapshot matches 1`] = `

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -1,4 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
+const BananasStandardOutputNoAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+const BananasStandardOutputWithAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
 
 exports[`arrow snapshot matches 1`] = `
 "import React, { Component } from 'react';
@@ -173,325 +221,31 @@ class componentName extends Component {
 export default componentName;"
 `;
 
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-}"
-`;
+exports[`ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
+exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
+exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-}"
-`;
+exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
+exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
+exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-}"
-`;
+exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
 
-exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
+exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
+exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-}"
-`;
+exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
-exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
+exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
 exports[`nonJSX snapshot matches 1`] = `
 "import React, { Component } from 'react';

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -1,52 +1,4 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
-const BananasStandardOutputNoAttributes = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\"
-    });
-  }
-
-}"
-`;
-
-const BananasStandardOutputWithAttributes = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      dataElement: \\"Image\\",
-      dataComponent: \\"Bananas\\",
-      dataSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
 
 exports[`arrow snapshot matches 1`] = `
 "import React, { Component } from 'react';
@@ -220,32 +172,6 @@ class componentName extends Component {
 
 export default componentName;"
 `;
-
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches 1`] = BananasStandardOutputNoAttributes;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches 1`] = BananasStandardOutputWithAttributes;
-
-exports[`ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches 1`] = BananasStandardOutputWithAttributes;
 
 exports[`nonJSX snapshot matches 1`] = `
 "import React, { Component } from 'react';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -285,12 +285,16 @@ class PizzaTranslator extends Component {
       onChangeText: text => this.setState({
         text
       }),
-      value: this.state.text
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
     }), /*#__PURE__*/React.createElement(Text, {
       style: {
         padding: 10,
         fontSize: 42
-      }
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
     }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
   }
 
@@ -302,8 +306,16 @@ export default function App() {
   }, /*#__PURE__*/React.createElement(Text, {
     style: {
       color: '#eee'
-    }
-  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
 }
 const styles = StyleSheet.create({
   container: {
@@ -388,8 +400,16 @@ export default function App() {
   }, /*#__PURE__*/React.createElement(Text, {
     style: {
       color: '#eee'
-    }
-  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
 }
 const styles = StyleSheet.create({
   container: {
@@ -450,12 +470,16 @@ class PizzaTranslator extends Component {
       onChangeText: text => this.setState({
         text
       }),
-      value: this.state.text
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
     }), /*#__PURE__*/React.createElement(Text, {
       style: {
         padding: 10,
         fontSize: 42
-      }
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
     }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
   }
 
@@ -567,8 +591,16 @@ export default function App() {
   }, /*#__PURE__*/React.createElement(Text, {
     style: {
       color: '#eee'
-    }
-  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
 }
 const styles = StyleSheet.create({
   container: {
@@ -632,12 +664,16 @@ class PizzaTranslator extends Component {
       onChangeText: text => this.setState({
         text
       }),
-      value: this.state.text
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
     }), /*#__PURE__*/React.createElement(Text, {
       style: {
         padding: 10,
         fontSize: 42
-      }
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
     }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
   }
 
@@ -1675,7 +1711,7 @@ it('Bananas/Pizza/App ignore components dataSourceFile=nomatch dataComponent=* d
   expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributes);
 });
 
-it('Bananas/Pizza/App only Bananas dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
+it('Bananas/Pizza/App only Bananas dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
     BananasPizzaAppStandardInput,
     {
@@ -1683,15 +1719,51 @@ it('Bananas/Pizza/App only Bananas dataSourceFile=* dataComponent=* dataElement=
       presets: ["@babel/preset-react"],
       plugins: [
         [plugin, { native: true, "ignore-components":[
-          ["filename-test.js","PizzaTranslator","*"],
-          ["filename-test.js","*","Text"],
-          ["filename-test.js","*","TextInput"],
-          ["filename-test.js","*","PizzaTranslator"],
-          ["filename-test.js","*","Bananas"],
+          // Pizza
+          ["filename-test.js","PizzaTranslator","View"],
+          // App
           ["filename-test.js","App","View"]
         ] }]
       ]
     },
   );
   expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasAttributes);
+});
+
+it('Bananas/Pizza/App only Pizza dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[
+          // Bananas
+          ["filename-test.js","Bananas","Image"],
+          // App
+          ["filename-test.js","App","View"]
+        ] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputPizzaAttributes);
+});
+
+it('Bananas/Pizza/App only App dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[
+          // Bananas
+          ["filename-test.js","Bananas","Image"],
+          // Pizza
+          ["filename-test.js","PizzaTranslator","View"]
+        ] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputAppAttributes);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -14,6 +14,55 @@ class Bananas extends Component {
   }
 }`;
 
+const BananasStandardOutputNoAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}"
+`;
+
+const BananasStandardOutputWithAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
 it('unknown-element snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component } from 'react';
@@ -694,7 +743,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=n
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
@@ -708,7 +757,7 @@ it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches', () => {
@@ -722,7 +771,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches', () => {
@@ -736,7 +785,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=*
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches', () => {
@@ -750,7 +799,7 @@ it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snaps
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches', () => {
@@ -764,7 +813,7 @@ it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snaps
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
@@ -778,7 +827,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snaps
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
 // This tests out matching only `dataElement`, with * for the others
@@ -793,7 +842,7 @@ it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapsho
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
 });
 
 // This tests out matching only `dataElement` and `dataComponent`, with * for `dataSourceFile`
@@ -808,7 +857,7 @@ it('ignore components dataSourceFile=* dataComponent=match dataElement=match sna
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
 });
 
 // This tests out matching on all 3 of our ignore list values
@@ -823,5 +872,5 @@ it('ignore components dataSourceFile=match dataComponent=match dataElement=match
       ]
     },
   );
-  expect(code).toMatchSnapshot();
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -135,6 +135,294 @@ const styles = StyleSheet.create({
 });"
 `;
 
+const BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasElements = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoPizzaElements = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasPizzaElements = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
 const BananasPizzaAppStandardOutputBananasPizzaAppAttributes = `
 "import React, { Component } from 'react';
 import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
@@ -1766,4 +2054,57 @@ it('Bananas/Pizza/App only App dataSourceFile=match dataComponent=match dataElem
     },
   );
   expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputAppAttributes);
+});
+
+it('Bananas/Pizza/App No Pizza Elements dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[
+          // Pizza Element
+          ["filename-test.js",null,"PizzaTranslator"]
+        ] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoPizzaElements);
+});
+
+it('Bananas/Pizza/App No Bananas Elements dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[
+          // Bananas Element
+          ["filename-test.js",null,"Bananas"]
+        ] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasElements);
+});
+
+it('Bananas/Pizza/App No Bananas/Pizza Elements dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[
+          // Bananas Element
+          ["filename-test.js",null,"Bananas"],
+          // Pizza Element
+          ["filename-test.js",null,"PizzaTranslator"]
+        ] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasPizzaElements);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1833,7 +1833,7 @@ it('Bananas ignore components dataSourceFile=nomatch dataComponent=nomatch dataE
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","nomatch","nomatch"]] }]
       ]
     },
   );
@@ -1847,7 +1847,7 @@ it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["*","nomatch","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["*","nomatch","nomatch"]] }]
       ]
     },
   );
@@ -1861,7 +1861,7 @@ it('Bananas ignore components dataSourceFile=nomatch dataComponent=* dataElement
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","*","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","*","nomatch"]] }]
       ]
     },
   );
@@ -1875,7 +1875,7 @@ it('Bananas ignore components dataSourceFile=nomatch dataComponent=nomatch dataE
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","*"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","nomatch","*"]] }]
       ]
     },
   );
@@ -1889,7 +1889,7 @@ it('Bananas ignore components dataSourceFile=* dataComponent=* dataElement=nomat
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","nomatch","nomatch"]] }]
       ]
     },
   );
@@ -1903,7 +1903,7 @@ it('Bananas ignore components dataSourceFile=* dataComponent=nomatch dataElement
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","nomatch","nomatch"]] }]
       ]
     },
   );
@@ -1917,7 +1917,7 @@ it('Bananas ignore components dataSourceFile=nomatch dataComponent=* dataElement
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","nomatch","nomatch"]] }]
       ]
     },
   );
@@ -1932,7 +1932,7 @@ it('Bananas ignore components dataSourceFile=* dataComponent=* dataElement=match
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["*","*","Image"]] }]
+        [plugin, { native: true, ignoreComponents:[["*","*","Image"]] }]
       ]
     },
   );
@@ -1947,7 +1947,7 @@ it('Bananas ignore components dataSourceFile=* dataComponent=match dataElement=m
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["*","Bananas","Image"]] }]
+        [plugin, { native: true, ignoreComponents:[["*","Bananas","Image"]] }]
       ]
     },
   );
@@ -1962,7 +1962,7 @@ it('Bananas ignore components dataSourceFile=match dataComponent=match dataEleme
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["filename-test.js","Bananas","Image"]] }]
+        [plugin, { native: true, ignoreComponents:[["filename-test.js","Bananas","Image"]] }]
       ]
     },
   );
@@ -1977,7 +1977,7 @@ it('Bananas/Pizza/App ignore components dataSourceFile=* dataComponent=* dataEle
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["*","*","*"]] }]
+        [plugin, { native: true, ignoreComponents:[["*","*","*"]] }]
       ]
     },
   );
@@ -1992,7 +1992,7 @@ it('Bananas/Pizza/App ignore components dataSourceFile=nomatch dataComponent=* d
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[["nomatch.js","*","*"]] }]
+        [plugin, { native: true, ignoreComponents:[["nomatch.js","*","*"]] }]
       ]
     },
   );
@@ -2006,7 +2006,7 @@ it('Bananas/Pizza/App only Bananas dataSourceFile=match dataComponent=match data
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Pizza
           ["filename-test.js","PizzaTranslator","View"],
           // App
@@ -2025,7 +2025,7 @@ it('Bananas/Pizza/App only Pizza dataSourceFile=match dataComponent=match dataEl
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Bananas
           ["filename-test.js","Bananas","Image"],
           // App
@@ -2044,7 +2044,7 @@ it('Bananas/Pizza/App only App dataSourceFile=match dataComponent=match dataElem
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Bananas
           ["filename-test.js","Bananas","Image"],
           // Pizza
@@ -2063,7 +2063,7 @@ it('Bananas/Pizza/App No Pizza Elements dataSourceFile=match dataComponent=match
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Pizza Element
           ["filename-test.js",null,"PizzaTranslator"]
         ] }]
@@ -2080,7 +2080,7 @@ it('Bananas/Pizza/App No Bananas Elements dataSourceFile=match dataComponent=mat
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Bananas Element
           ["filename-test.js",null,"Bananas"]
         ] }]
@@ -2097,7 +2097,7 @@ it('Bananas/Pizza/App No Bananas/Pizza Elements dataSourceFile=match dataCompone
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[
+        [plugin, { native: true, ignoreComponents:[
           // Bananas Element
           ["filename-test.js",null,"Bananas"],
           // Pizza Element

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1682,14 +1682,14 @@ it('Bananas/Pizza/App only Bananas dataSourceFile=* dataComponent=* dataElement=
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true, "ignore-components":[[
-          "filename-test.js","PizzaTranslator","*",
-          "filename-test.js","*","Text",
-          "filename-test.js","*","TextInput",
-          "filename-test.js","*","PizzaTranslator",
-          "filename-test.js","*","Bananas",
-          "filename-test.js","App","View",
-        ]] }]
+        [plugin, { native: true, "ignore-components":[
+          ["filename-test.js","PizzaTranslator","*"],
+          ["filename-test.js","*","Text"],
+          ["filename-test.js","*","TextInput"],
+          ["filename-test.js","*","PizzaTranslator"],
+          ["filename-test.js","*","Bananas"],
+          ["filename-test.js","App","View"]
+        ] }]
       ]
     },
   );

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -695,6 +695,151 @@ class Bananas extends Component {
   expect(code).toMatchSnapshot();
 });
 
+it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["*","nomatch","nomatch"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","*","nomatch"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","*"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+
 it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component } from 'react';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2,6 +2,776 @@ const babel = require('babel-core');
 const plugin = require('../');
 const assert = require('assert');
 
+const BananasPizzaAppStandardInput = `import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = "String";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { text: '' };
+  }
+
+  render() {
+    return <View style={{ padding: 10 }}>
+        <TextInput style={{
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      }} placeholder="Type here to translate!" // not supported on iOS
+      onChangeText={text => this.setState({ text })} value={this.state.text} />
+        <Text style={{ padding: 10, fontSize: 42 }}>
+          {this.state.text.split(' ').map(word => word && '🍕').join(' ')}
+        </Text>
+      </View>;
+  }
+}
+
+export default function App() {
+  return <View style={styles.container}>
+      <Text style={{ color: '#eee' }}>FullStory ReactNative testing app</Text>
+      <Bananas />
+      <PizzaTranslator />
+    </View>;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});`;
+
+const BananasPizzaAppStandardOutputNoAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      }
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      }
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    }
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasPizzaAppAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      }
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      }
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    }
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputPizzaAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    }
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputAppAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      }
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      }
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasPizzaAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    }
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, null), /*#__PURE__*/React.createElement(PizzaTranslator, null));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputBananasAppAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      dataElement: \\"Image\\",
+      dataComponent: \\"Bananas\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      }
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      }
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
+const BananasPizzaAppStandardOutputPizzaAppAttributes = `
+"import React, { Component } from 'react';
+import { StyleSheet, Text, TextInput, View, Image, UIManager } from 'react-native';
+UIManager.getViewManagerConfig('RCTView').NativeProps.fsClass = \\"String\\";
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\"
+    });
+  }
+
+}
+
+class PizzaTranslator extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: ''
+    };
+  }
+
+  render() {
+    return /*#__PURE__*/React.createElement(View, {
+      style: {
+        padding: 10
+      },
+      dataElement: \\"View\\",
+      dataComponent: \\"PizzaTranslator\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(TextInput, {
+      style: {
+        backgroundColor: '#000',
+        color: '#eee',
+        padding: 8
+      },
+      placeholder: \\"Type here to translate!\\" // not supported on iOS
+      ,
+      onChangeText: text => this.setState({
+        text
+      }),
+      value: this.state.text,
+      dataElement: \\"TextInput\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }), /*#__PURE__*/React.createElement(Text, {
+      style: {
+        padding: 10,
+        fontSize: 42
+      },
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, this.state.text.split(' ').map(word => word && '🍕').join(' ')));
+  }
+
+}
+
+export default function App() {
+  return /*#__PURE__*/React.createElement(View, {
+    style: styles.container,
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    style: {
+      color: '#eee'
+    },
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"FullStory ReactNative testing app\\"), /*#__PURE__*/React.createElement(Bananas, {
+    dataElement: \\"Bananas\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }), /*#__PURE__*/React.createElement(PizzaTranslator, {
+    dataElement: \\"PizzaTranslator\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }));
+}
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'stretch',
+    backgroundColor: '#222',
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});"
+`;
+
 const BananasStandardInput = `import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -732,7 +1502,7 @@ export default PureComponentName;
   expect(code).toMatchSnapshot();
 });
 
-it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -760,7 +1530,7 @@ it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
-it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -774,7 +1544,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
-it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -788,7 +1558,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=*
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
-it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -802,7 +1572,7 @@ it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snaps
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
-it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -816,7 +1586,7 @@ it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snaps
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
 });
 
-it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -831,7 +1601,7 @@ it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snaps
 });
 
 // This tests out matching only `dataElement`, with * for the others
-it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -846,7 +1616,7 @@ it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapsho
 });
 
 // This tests out matching only `dataElement` and `dataComponent`, with * for `dataSourceFile`
-it('ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -861,7 +1631,7 @@ it('ignore components dataSourceFile=* dataComponent=match dataElement=match sna
 });
 
 // This tests out matching on all 3 of our ignore list values
-it('ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+it('Bananas ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -873,4 +1643,55 @@ it('ignore components dataSourceFile=match dataComponent=match dataElement=match
     },
   );
   expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
+});
+
+// This tests out matching on all 3 of our ignore list values via *
+it('Bananas/Pizza/App ignore components dataSourceFile=* dataComponent=* dataElement=* snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["*","*","*"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputNoAttributes);
+});
+
+// This tests out matching on all 3 of our ignore list values
+it('Bananas/Pizza/App ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["nomatch.js","*","*"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributes);
+});
+
+it('Bananas/Pizza/App only Bananas dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasPizzaAppStandardInput,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[[
+          "filename-test.js","PizzaTranslator","*",
+          "filename-test.js","*","Text",
+          "filename-test.js","*","TextInput",
+          "filename-test.js","*","PizzaTranslator",
+          "filename-test.js","*","Bananas",
+          "filename-test.js","App","View",
+        ]] }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasAttributes);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -671,7 +671,7 @@ export default PureComponentName;
   expect(code).toMatchSnapshot();
 });
 
-it('tags blocklist no-match snapshot matches', () => {
+it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component } from 'react';
 import { Image } from 'react-native';
@@ -688,14 +688,14 @@ class Bananas extends Component {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
       plugins: [
-        [plugin, { native: true }]
+        [plugin, { native: true, "ignore-components":[["nomatch.js","nomatch","nomatch"]] }]
       ]
     },
   );
   expect(code).toMatchSnapshot();
 });
 
-it('tags dataElement blocklist excluded snapshot matches', () => {
+it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component } from 'react';
 import { Image } from 'react-native';
@@ -713,6 +713,54 @@ class Bananas extends Component {
       presets: ["@babel/preset-react"],
       plugins: [
         [plugin, { native: true, "ignore-components":[["*","*","Image"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["*","Bananas","Image"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["filename-test.js","Bananas","Image"]] }]
       ]
     },
   );

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -670,3 +670,51 @@ export default PureComponentName;
   );
   expect(code).toMatchSnapshot();
 });
+
+it('tags blocklist no-match snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('tags dataElement blocklist excluded snapshot matches', () => {
+  const { code } = babel.transform(
+`import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`,
+    {
+      filename: "./filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true, "ignore-components":[["*","*","Image"]] }]
+      ]
+    },
+  );
+  expect(code).toMatchSnapshot();
+});

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2,6 +2,18 @@ const babel = require('babel-core');
 const plugin = require('../');
 const assert = require('assert');
 
+const BananasStandardInput = `import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
+  }
+}`;
+
 it('unknown-element snapshot matches', () => {
   const { code } = babel.transform(
 `import React, { Component } from 'react';
@@ -673,17 +685,7 @@ export default PureComponentName;
 
 it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -697,17 +699,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -721,17 +713,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -745,17 +727,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=nomatch dataComponent=nomatch dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -769,17 +741,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=* dataComponent=* dataElement=nomatch snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -793,17 +755,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=* dataComponent=nomatch dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -817,17 +769,7 @@ class Bananas extends Component {
 
 it('ignore components dataSourceFile=nomatch dataComponent=* dataElement=* snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -839,20 +781,10 @@ class Bananas extends Component {
   expect(code).toMatchSnapshot();
 });
 
-
+// This tests out matching only `dataElement`, with * for the others
 it('ignore components dataSourceFile=* dataComponent=* dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -864,19 +796,10 @@ class Bananas extends Component {
   expect(code).toMatchSnapshot();
 });
 
+// This tests out matching only `dataElement` and `dataComponent`, with * for `dataSourceFile`
 it('ignore components dataSourceFile=* dataComponent=match dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],
@@ -888,19 +811,10 @@ class Bananas extends Component {
   expect(code).toMatchSnapshot();
 });
 
+// This tests out matching on all 3 of our ignore list values
 it('ignore components dataSourceFile=match dataComponent=match dataElement=match snapshot matches', () => {
   const { code } = babel.transform(
-`import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" />;
-  }
-}`,
+    BananasStandardInput,
     {
       filename: "./filename-test.js",
       presets: ["@babel/preset-react"],

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function isReactFragment(openingElement) {
 }
 
 function applyAttributes(t, openingElement, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption) {
-  const [ componentAttributeName, elementAttributeName, sourceFileAttributeName ] = attributeNames;
+  const [componentAttributeName, elementAttributeName, sourceFileAttributeName] = attributeNames;
   if (!openingElement
       || isReactFragment(openingElement)
       || !openingElement.node
@@ -128,11 +128,11 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
 
   const elementName = openingElement.node.name.name || 'unknown'
 
-  const ignoredComponentFromOptions = ignoreComponentsFromOption && !!ignoreComponentsFromOption.find(component => 
-    matchesIgnoreRule(component[0], sourceFileName) && 
-    matchesIgnoreRule(component[1], componentName) && 
+  const ignoredComponentFromOptions = ignoreComponentsFromOption && !!ignoreComponentsFromOption.find(component =>
+    matchesIgnoreRule(component[0], sourceFileName) &&
+    matchesIgnoreRule(component[1], componentName) &&
     matchesIgnoreRule(component[2], elementName)
-)
+  )
 
   let ignoredElement = false
   // Add a stable attribute for the element name but only for non-DOM names
@@ -154,9 +154,9 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
 
   // Add a stable attribute for the component name (absent for non-root elements)
   if (
-    componentName 
+    componentName
     && !ignoredComponentFromOptions
-    && !hasNodeNamed(openingElement, componentAttributeName)){
+    && !hasNodeNamed(openingElement, componentAttributeName)) {
     openingElement.node.attributes.push(
       t.jSXAttribute(
         t.jSXIdentifier(componentAttributeName),
@@ -170,11 +170,8 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
     sourceFileName
     && !ignoredComponentFromOptions
     && (componentName || ignoredElement === false)
-    && !openingElement.node.attributes.find(node => {
-      if (!node.name) return
-      return node.name.name === sourceFileAttributeName
-    }
-  )){
+    && !hasNodeNamed(openingElement, sourceFileAttributeName)
+  ) {
     openingElement.node.attributes.push(
       t.jSXAttribute(
         t.jSXIdentifier(sourceFileAttributeName),

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ module.exports = function({ types: t }) {
         })
         if (!render || !render.traverse) return
 
+        const ignoreComponentsFromOption = this.ignoreComponentsFromOption;
+
         render.traverse({
           ReturnStatement(returnStatement) {
             const arg = returnStatement.get('argument')
@@ -62,7 +64,7 @@ module.exports = function({ types: t }) {
               name.node && name.node.name,
               sourceFileNameFromState(state),
               attributeNamesFromState(state),
-              this.ignoreComponentsFromOption,
+              ignoreComponentsFromOption
             )
           }
         })
@@ -125,7 +127,7 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
   if (!openingElement.node.attributes) openingElement.node.attributes = {}
 
   const elementName = openingElement.node.name.name || 'unknown'
-  let ignoredComponentFromOptions = ignoreComponentsFromOption.find(component => {
+  const ignoredComponentFromOptions = ignoreComponentsFromOption?.find(component => {
     let match = true;
     if (component[0] !== '*' && component[0] !== sourceFileName) match = false;
     else if (component[1] !== '*' && component[1] !== componentName) match = false;

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
   if (!openingElement.node.attributes) openingElement.node.attributes = {}
 
   const elementName = openingElement.node.name.name || 'unknown'
-  const ignoredComponentFromOptions = ignoreComponentsFromOption?.find(component => {
+  const ignoredComponentFromOptions = ignoreComponentsFromOption && ignoreComponentsFromOption.find(component => {
     let match = true;
     if (component[0] !== '*' && component[0] !== sourceFileName) match = false;
     else if (component[1] !== '*' && component[1] !== componentName) match = false;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const nativeSourceFileName = 'dataSourceFile';
 
 const nativeOptionName = 'native';
 const annotateFragmentsOptionName = 'annotate-fragments'
-const ignoreComponentsOptionName = "ignore-components"
+const ignoreComponentsOptionName = 'ignoreComponents'
 
 module.exports = function({ types: t }) {
   return {

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const nativeSourceFileName = 'dataSourceFile';
 const nativeOptionName = 'native';
 const annotateFragmentsOptionName = 'annotate-fragments'
 
+const commentStringIgnoreComponent = "fullstory-babel-plugin-annotate-react-disable-component"
+
 module.exports = function({ types: t }) {
   return {
     visitor: {
@@ -171,6 +173,11 @@ function processJSXElement(annotateFragments, t, jsxElement, componentName, sour
     return
   }
   const openingElement = jsxElement.get('openingElement')
+
+  const trailingComments = openingElement?.node?.name?.trailingComments
+  if (trailingComments && trailingComments.find(c => c.value.includes(commentStringIgnoreComponent))) {
+    return
+  }
 
   applyAttributes(t, openingElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName)
 

--- a/index.js
+++ b/index.js
@@ -8,11 +8,13 @@ const nativeSourceFileName = 'dataSourceFile';
 
 const nativeOptionName = 'native';
 const annotateFragmentsOptionName = 'annotate-fragments'
-
-const commentStringIgnoreComponent = "fullstory-babel-plugin-annotate-react-disable-component"
+const ignoreComponentsOptionName = "ignore-components"
 
 module.exports = function({ types: t }) {
   return {
+    pre() {
+      this.ignoreComponentsFromOption = this.opts[ignoreComponentsOptionName] || [];
+    },
     visitor: {
       FunctionDeclaration(path, state) {
         if (!path.node.id || !path.node.id.name) return
@@ -22,7 +24,8 @@ module.exports = function({ types: t }) {
           path,
           path.node.id.name,
           sourceFileNameFromState(state),
-          ...attributeNamesFromState(state)
+          attributeNamesFromState(state),
+          this.ignoreComponentsFromOption,
         )
       },
       ArrowFunctionExpression(path, state) {
@@ -33,7 +36,8 @@ module.exports = function({ types: t }) {
           path,
           path.parent.id.name,
           sourceFileNameFromState(state),
-          ...attributeNamesFromState(state)
+          attributeNamesFromState(state),
+          this.ignoreComponentsFromOption,
         )
       },
       ClassDeclaration(path, state) {
@@ -57,7 +61,8 @@ module.exports = function({ types: t }) {
               arg,
               name.node && name.node.name,
               sourceFileNameFromState(state),
-              ...attributeNamesFromState(state)
+              attributeNamesFromState(state),
+              this.ignoreComponentsFromOption,
             )
           }
         })
@@ -108,7 +113,8 @@ function isReactFragment(openingElement) {
   )
 }
 
-function applyAttributes(t, openingElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName) {
+function applyAttributes(t, openingElement, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption) {
+  const [ componentAttributeName, elementAttributeName, sourceFileAttributeName ] = attributeNames;
   if (!openingElement
       || isReactFragment(openingElement)
       || !openingElement.node
@@ -118,30 +124,44 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
   }
   if (!openingElement.node.attributes) openingElement.node.attributes = {}
 
+  const elementName = openingElement.node.name.name || 'unknown'
+  let ignoredComponentFromOptions = ignoreComponentsFromOption.find(component => {
+    let match = true;
+    if (component[0] !== '*' && component[0] !== sourceFileName) match = false;
+    else if (component[1] !== '*' && component[1] !== componentName) match = false;
+    else if (component[2] !== '*' && component[2] !== elementName) match = false;
+    
+    return match
+  }) !== undefined
+
   let ignoredElement = false
   // Add a stable attribute for the element name but only for non-DOM names
-  if(openingElement.node.attributes.find(node => {
+  if (
+    !ignoredComponentFromOptions
+    && openingElement.node.attributes.find(node => {
     if (!node.name) return
     return node.name.name === elementAttributeName
-  }) == null){
-    const name = openingElement.node.name.name || 'unknown'
-    if (ignoredElements.includes(name)) {
+  }) == undefined){
+    if (defaultIgnoredElements.includes(elementName)) {
       ignoredElement = true
     } else {
       openingElement.node.attributes.push(
         t.jSXAttribute(
           t.jSXIdentifier(elementAttributeName),
-          t.stringLiteral(name)
+          t.stringLiteral(elementName)
         )
       )
     }
   }
 
   // Add a stable attribute for the component name (absent for non-root elements)
-  if(componentName && (openingElement.node.attributes.find(node => {
-    if (!node.name) return
-    return node.name.name === componentAttributeName
-  }) == null)){
+  if (
+    componentName 
+    && !ignoredComponentFromOptions
+    && (openingElement.node.attributes.find(node => {
+      if (!node.name) return
+      return node.name.name === componentAttributeName
+    }) == undefined)){
     openingElement.node.attributes.push(
       t.jSXAttribute(
         t.jSXIdentifier(componentAttributeName),
@@ -151,14 +171,15 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
   }
 
   // Add a stable attribute for the source file name (absent for non-root elements)
-  if(
+  if (
     sourceFileName
+    && !ignoredComponentFromOptions
     && (componentName || ignoredElement === false)
     && openingElement.node.attributes.find(node => {
       if (!node.name) return
       return node.name.name === sourceFileAttributeName
     }
-  ) == null){
+  ) == undefined){
     openingElement.node.attributes.push(
       t.jSXAttribute(
         t.jSXIdentifier(sourceFileAttributeName),
@@ -168,18 +189,13 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, compo
   }
 }
 
-function processJSXElement(annotateFragments, t, jsxElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName) {
+function processJSXElement(annotateFragments, t, jsxElement, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption) {
   if (!jsxElement) {
     return
   }
   const openingElement = jsxElement.get('openingElement')
 
-  const trailingComments = openingElement?.node?.name?.trailingComments
-  if (trailingComments && trailingComments.find(c => c.value.includes(commentStringIgnoreComponent))) {
-    return
-  }
-
-  applyAttributes(t, openingElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName)
+  applyAttributes(t, openingElement, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption)
 
   const children = jsxElement.get('children')
   if (children && children.length) {
@@ -188,15 +204,15 @@ function processJSXElement(annotateFragments, t, jsxElement, componentName, sour
       // Children don't receive the data-component attribute so we pass null for componentName unless it's the first child of a Fragment with a node and `annotateFragments` is true
       if (shouldSetComponentName && children[i].get('openingElement') && children[i].get('openingElement').node) {
         shouldSetComponentName = false
-        processJSXElement(annotateFragments, t, children[i], componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName, annotateFragments)
+        processJSXElement(annotateFragments, t, children[i], componentName, sourceFileName, attributeNames, ignoreComponentsFromOption)
       } else {
-        processJSXElement(annotateFragments, t, children[i], null, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName, annotateFragments)
+        processJSXElement(annotateFragments, t, children[i], null, sourceFileName, attributeNames, ignoreComponentsFromOption)
       }
     }
   }
 }
 
-function functionBodyPushAttributes(annotateFragments, t, path, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName) {
+function functionBodyPushAttributes(annotateFragments, t, path, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption) {
   let jsxElement = null
   const functionBody = path.get('body').get('body')
   if (functionBody.parent && functionBody.parent.type === 'JSXElement') {
@@ -219,11 +235,11 @@ function functionBodyPushAttributes(annotateFragments, t, path, componentName, s
     jsxElement = arg
   }
   if (!jsxElement) return
-  processJSXElement(annotateFragments, t, jsxElement, componentName, sourceFileName, componentAttributeName, elementAttributeName, sourceFileAttributeName)
+  processJSXElement(annotateFragments, t, jsxElement, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption)
 }
 
 // We don't write data-element attributes for these names
-const ignoredElements = [
+const defaultIgnoredElements = [
   'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio',
   'b', 'base', 'bdi', 'bdo', 'blockquote', 'body', 'br', 'button',
   'canvas', 'caption', 'cite', 'code', 'col', 'colgroup',


### PR DESCRIPTION
https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react/issues/33#issuecomment-923267797

Add a way to use comments to skip annotation for certain components. This could be useful when certain component (such as material-ui's `ThemeProvider`) does it's own run time `prop-type` checks and throw warnings on the `data-*` attributes that we add.