### PR TITLE
update config for running local dev RN sample

### DIFF
--- a/samples/react-native-app/android/app/build.gradle
+++ b/samples/react-native-app/android/app/build.gradle
@@ -92,7 +92,7 @@ apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gra
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = false
+def enableSeparateBuildPerCPUArchitecture = true
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.

--- a/samples/react-native-app/babel.config.js
+++ b/samples/react-native-app/babel.config.js
@@ -1,7 +1,11 @@
 module.exports = function(api) {
-  api.cache(true);
+  api.cache.never()
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['module:fullstory-babel-plugin-annotate-react'],
+    plugins: [
+      // This is the local reference @fullstory/babel-plugin-annotate-react
+      // To use in your projects you would replace '../..' with '@fullstory/babel-plugin-annotate-react'
+      ['../..', { native: true, }]
+    ],
   };
 };

--- a/samples/react-native-app/ios/reactnativeapp.xcodeproj/project.pbxproj
+++ b/samples/react-native-app/ios/reactnativeapp.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8085}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/samples/react-native-app/metro.config.js
+++ b/samples/react-native-app/metro.config.js
@@ -1,5 +1,9 @@
 module.exports = {
+  resetCache: true,
   transformer: {
     assetPlugins: ['expo-asset/tools/hashAssetFiles'],
+  },
+  server: {
+    port: 8085,
   },
 };

--- a/samples/react-native-app/package-lock.json
+++ b/samples/react-native-app/package-lock.json
@@ -5930,9 +5930,6 @@
         "nan": "^2.12.1"
       }
     },
-    "fullstory-babel-plugin-annotate-react": {
-      "version": "file:../.."
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",

--- a/samples/react-native-app/package.json
+++ b/samples/react-native-app/package.json
@@ -8,7 +8,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "fullstory-babel-plugin-annotate-react": "file:../../",
     "expo": "~37.0.3",
     "expo-splash-screen": "^0.2.3",
     "expo-updates": "~0.2.0",


### PR DESCRIPTION
some small local dev changes for the RN sample app:
1. stop metro and babel from caching the plugin - this does make it so that the loading the bundle takes longer, but since the sample app is mainly used for developing changes for the plugin, we can probably live with the slowness if it means we no longer have to clear metro cache manually
2. set the default metro port to 8085 (since the dev proxy we have internally is running on 8080/8081)