### PR TITLE
initiating hold + deploy steps only for tagged branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
   version: 2
   test-deploy:
     jobs:
-      - build-babel-plugin
+      - build-babel-plugin:
         filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,13 +44,23 @@ workflows:
   test-deploy:
     jobs:
       - build-babel-plugin
+        filters:
+            tags:
+              only: /.*/
       - hold:
           type: approval
           requires:
             - build-babel-plugin
           filters:
+            tags:
+              only: /^v.*/
             branches:
-              only: "master"
+              ignore: /.*/
       - deploy-babel-plugin:
           requires:
             - hold
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Updating our circle CI config to build off of a tag, rather than the `master` branch.