### PR TITLE
skip known-incompatible node modules

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2108,3 +2108,59 @@ it('Bananas/Pizza/App No Bananas/Pizza Elements dataSourceFile=match dataCompone
   );
   expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasPizzaElements);
 });
+
+it('Bananas incompatible plugin react-native-navigation source snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "test/node_modules/react-native-navigation/filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
+});
+
+it('Bananas incompatible plugin victory-core source snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "test/node_modules/victory-core/filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
+});
+
+it('Bananas incompatible plugin victory-valid source snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "test/node_modules/victory-valid/filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithAttributes);
+});
+
+it('Bananas incompatible plugin @react-navigation source snapshot matches', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "test/node_modules/@react-navigation/core/filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, { native: true }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
+});

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2109,20 +2109,6 @@ it('Bananas/Pizza/App No Bananas/Pizza Elements dataSourceFile=match dataCompone
   expect(code).toMatchInlineSnapshot(BananasPizzaAppStandardOutputBananasPizzaAppAttributesNoBananasPizzaElements);
 });
 
-it('Bananas incompatible plugin react-native-navigation source snapshot matches', () => {
-  const { code } = babel.transform(
-    BananasStandardInput,
-    {
-      filename: "test/node_modules/react-native-navigation/filename-test.js",
-      presets: ["@babel/preset-react"],
-      plugins: [
-        [plugin, { native: true }]
-      ]
-    },
-  );
-  expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
-});
-
 it('Bananas incompatible plugin victory-core source snapshot matches', () => {
   const { code } = babel.transform(
     BananasStandardInput,

--- a/index.js
+++ b/index.js
@@ -11,8 +11,13 @@ const annotateFragmentsOptionName = 'annotate-fragments';
 const ignoreComponentsOptionName = 'ignoreComponents';
 
 const knownIncompatiblePlugins = [
+  // This module has issues with overlays becoming unclickable.
   'react-native-navigation',
+  // This module might be causing an issue preventing clicks. For safety, we won't run on this module.
+  'react-native-testfairy',
+  // This module checks for unexpected property keys and throws an exception.
   '@react-navigation',
+  // The victory* modules use `dataComponent` and we get a collision.
   'victory',
   'victory-area',
   'victory-axis',

--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ const annotateFragmentsOptionName = 'annotate-fragments';
 const ignoreComponentsOptionName = 'ignoreComponents';
 
 const knownIncompatiblePlugins = [
-  // This module has issues with overlays becoming unclickable.
-  'react-native-navigation',
   // This module might be causing an issue preventing clicks. For safety, we won't run on this module.
   'react-native-testfairy',
   // This module checks for unexpected property keys and throws an exception.

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
 
   const elementName = openingElement.node.name.name || 'unknown'
 
-  let ignoredComponentFromOptions = ignoreComponentsFromOption && !!ignoreComponentsFromOption.find(component =>
+  const ignoredComponentFromOptions = ignoreComponentsFromOption && !!ignoreComponentsFromOption.find(component =>
     matchesIgnoreRule(component[0], sourceFileName) &&
     matchesIgnoreRule(component[1], componentName) &&
     matchesIgnoreRule(component[2], elementName)

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ const nativeOptionName = 'native';
 const annotateFragmentsOptionName = 'annotate-fragments'
 const ignoreComponentsOptionName = 'ignoreComponents'
 
+const knownIncompatiblePlugins = ["react-native-navigation", "victory-native", "react-navigation"]
+
 module.exports = function({ types: t }) {
   return {
     pre() {
@@ -94,6 +96,15 @@ function sourceFileNameFromFullSourceFileName(name) {
   }
 }
 
+function isKnownIncompatiblePlugin(fullSourceFileName, pluginName) {
+  if (fullSourceFileName == undefined) {
+    return false
+  }
+
+  return fullSourceFileName.includes("/node_modules/" + pluginName + "/") || 
+         fullSourceFileName.includes("\\node_modules\\" + pluginName + "\\")
+}
+
 function attributeNamesFromState(state) {
   if(state.opts[nativeOptionName] === true) {
     return [nativeComponentName, nativeElementName, nativeSourceFileName]
@@ -144,6 +155,12 @@ function applyAttributes(t, openingElement, componentName, fullSourceFileName, a
 
   if (!ignoredComponentFromOptions) {
     // check for any known bad plugins
+    for (let i = 0; i < knownIncompatiblePlugins.length; i += 1) {
+      if (isKnownIncompatiblePlugin(fullSourceFileName, knownIncompatiblePlugins[i])) {
+        ignoredComponentFromOptions = true
+        break
+      }
+    }
   }
 
   let ignoredElement = false

--- a/index.js
+++ b/index.js
@@ -7,10 +7,43 @@ const nativeElementName = 'dataElement';
 const nativeSourceFileName = 'dataSourceFile';
 
 const nativeOptionName = 'native';
-const annotateFragmentsOptionName = 'annotate-fragments'
-const ignoreComponentsOptionName = 'ignoreComponents'
+const annotateFragmentsOptionName = 'annotate-fragments';
+const ignoreComponentsOptionName = 'ignoreComponents';
 
-const knownIncompatiblePlugins = ["react-native-navigation", "victory-native", "react-navigation"]
+const knownIncompatiblePlugins = [
+  'react-native-navigation',
+  '@react-navigation',
+  'victory',
+  'victory-area',
+  'victory-axis',
+  'victory-bar',
+  'victory-box-plot',
+  'victory-brush-container',
+  'victory-brush-line',
+  'victory-candlestick',
+  'victory-canvas',
+  'victory-chart',
+  'victory-core',
+  'victory-create-container',
+  'victory-cursor-container',
+  'victory-errorbar',
+  'victory-group',
+  'victory-histogram',
+  'victory-legend',
+  'victory-line',
+  'victory-native',
+  'victory-pie',
+  'victory-polar-axis',
+  'victory-scatter',
+  'victory-selection-container',
+  'victory-shared-events',
+  'victory-stack',
+  'victory-tooltip',
+  'victory-vendor',
+  'victory-voronoi',
+  'victory-voronoi-container',
+  'victory-zoom-container',
+];
 
 module.exports = function({ types: t }) {
   return {


### PR DESCRIPTION
There are certain node modules that we know are incompatible with our annotate plugin. They either reuse the `dataElement` attribute for their own purpose ([VictoryLib](https://formidable.com/open-source/victory/docs/native/)) or disallow extra attributes on their object (https://github.com/react-navigation/react-navigation).

This PR adds functionality to have a hardcoded blocklist that we will maintain as needed.