### PR TITLE
release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Added a blocklist for known-incompatible node modules.
+
 ## 2.2.0
 
 - Added the ability to skip annotating certain elements. See the README for usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/babel-plugin-annotate-react",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fullstory/babel-plugin-annotate-react",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A Babel plugin that annotates React components, making them easier to target with FullStory search",
   "main": "index.js",
   "homepage": "https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react",


### PR DESCRIPTION
This PR releases 2.2.1 with the internal, hard-coded blocklist for known-incompatible node modules.