### PR TITLE
Add setFSTagName option for mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,29 @@ Final render:
       <h1>Hello world</h1>
     </div>
 
+## React Native
+
 To activate React Native support you must pass in a `native` plugin option like so:
 
     plugins: [
       ["@fullstory/babel-plugin-annotate-react", { native: true }]
     ]
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `componentAttribute: 'fsTagName'` to generate better privacy selectors. 
-(Important note: you may need to update or add to pre-existing privacy selectors and defined elements after making this change.)
+### React Native with FullStory 
+
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` option to `'fsTagName'` to generate better privacy selectors. 
+
+⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `componentAttribute: 'fsTagName'`.
 <!-- todo: write up a KB article to walk customers through transitioning from `dataComponent` to `fsTagName` if they have pre-existing privacy selectors or defined elements and link to it here -->
 
     plugins: [
+      '@fullstory/react-native',
       ["@fullstory/babel-plugin-annotate-react", { native: true, componentAttribute: 'fsTagName' }]
     ]
+
+See [Getting Started with FullStory React Native Capture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture) for more info.
+
+## Fragments
 
 By default, the plugin does not annotate `React.Fragment`s because they may or may not contain a child that ends up being an HTML element.
 
@@ -76,12 +86,14 @@ If you would like the plugin to attempt to annotate the first HTML element creat
       ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
     ]
 
+## Ignoring Components
+
 If you would like the plugin to skip the annotation for certain components, use the `ignoreComponents` option:
 
 ```javascript
   plugins: [
       [
-        '../..',
+        "@fullstory/babel-plugin-annotate-react",
         {
           ignoreComponents:[
             // each item must be a string array containing three items: file name, component name, element name
@@ -95,6 +107,8 @@ If you would like the plugin to skip the annotation for certain components, use 
       ],
   ]
 ```
+
+## Sample Apps
 
 We have a few samples to demonstrate this plugin:
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ To activate React Native support you must pass in a `native` plugin option like 
 
 ### React Native with FullStory 
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` option to `'fsTagName'` to generate better privacy selectors. 
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` and `elementAttribute` options both to `'fsTagName'` to generate better privacy selectors. 
 
-⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `componentAttribute: 'fsTagName'`.
-<!-- todo: write up a KB article to walk customers through transitioning from `dataComponent` to `fsTagName` if they have pre-existing privacy selectors or defined elements and link to it here -->
+⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `componentAttribute` and `elementAttribute` set.
+<!-- todo: write up a KB article to walk customers through transitioning to `fsTagName` if they have pre-existing privacy selectors or defined elements; link to it here -->
 
     plugins: [
       '@fullstory/react-native',
-      ["@fullstory/babel-plugin-annotate-react", {
+      ["@fullstory/annotate-react", {
         native: true,
         componentAttribute: 'fsTagName',
         elementAttribute: 'fsTagName',

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 This is a Babel plugin that annotates React components with stable attributes that can be used to search and select using [FullStory](https://www.fullstory.com/). This is most useful when using a React system that generates dynamic names for Components or rearranges elements.
 
 For React on the web the attributes are `data-component`, `data-element`, and `data-source-file`. For React Native the attributes are `dataComponent`, `dataElement`, and `dataSourceFile`.
+These attribute names may be customized by setting the `componentAttribute`, `elementAttribute`, and `sourceFileAttribute` configuration options.
 
 The component attribute names the `React.Component` and the element attribute names the original native elements like `View` or `Image` or an emitter of DOM elements like `Fragment`.
 
@@ -42,6 +43,13 @@ To activate React Native support you must pass in a `native` plugin option like 
       ["@fullstory/babel-plugin-annotate-react", { native: true }]
     ]
 
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `componentAttribute: 'fsTagName'` to generate better privacy selectors. 
+(Important note: you may need to update or add to pre-existing privacy selectors and defined elements after making this change.)
+<!-- todo: write up a KB article to walk customers through transitioning from `dataComponent` to `fsTagName` if they have pre-existing privacy selectors or defined elements and link to it here -->
+
+    plugins: [
+      ["@fullstory/babel-plugin-annotate-react", { native: true, componentAttribute: 'fsTagName' }]
+    ]
 
 By default, the plugin does not annotate `React.Fragment`s because they may or may not contain a child that ends up being an HTML element.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is a Babel plugin that annotates React components with stable attributes that can be used to search and select using [FullStory](https://www.fullstory.com/). This is most useful when using a React system that generates dynamic names for Components or rearranges elements.
 
-For React on the web the attributes are `data-component`, `data-element`, and `data-source-file`. For React Native the attributes are `dataComponent`, `dataElement`, and `dataSourceFile`, or [`fsTagName`](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) and `dataSourceFile` with `setFSTagName` enabled.
+For React on the web the attributes are `data-component`, `data-element`, and `data-source-file`. For React Native the attributes are `dataComponent`, `dataElement`, and `dataSourceFile`.
 
 The component attribute names the `React.Component` and the element attribute names the original native elements like `View` or `Image` or an emitter of DOM elements like `Fragment`.
 
@@ -44,25 +44,29 @@ To activate React Native support you must pass in a `native` plugin option like 
       ["@fullstory/babel-plugin-annotate-react", { native: true }]
     ]
 
-### React Native with FullStory 
+See [Getting Started with FullStory React Native Capture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture) for more info.
 
+### `setFSTagName` setting
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `setFSTagName: true` to generate better privacy selectors by setting [`fsTagName`](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) rather than `dataElement` and `dataComponent`.
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `setFSTagName: true` to generate better privacy selectors. This setting will automatically set [`fsTagName`](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) with the value of `dataElement` or `dataComponent`, which will truncate the privacy selector and avoid duplicate naming.
+
+Example:
+* Before `RCTSafeAreaView[data-source-file="App.tsx"][data-element="SafeAreaView"][data-component="App"]`
+* After `App[data-source-file="App.tsx"]`
+
+```
+plugins: [
+  '@fullstory/react-native',
+  ["@fullstory/annotate-react", {
+    native: true,
+    setFSTagName: true,
+  }]
+]
+```
 
 ⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `setFSTagName: true`.
 <!-- todo: write up a KB article to walk customers through transitioning to `fsTagName` if they have pre-existing privacy selectors or defined elements; link to it here -->
 
-    plugins: [
-      '@fullstory/react-native',
-      ["@fullstory/annotate-react", {
-        native: true,
-        setFSTagName: true,
-      }]
-    ]
-
-(Note: with this configuration, the component will take precedence over the element for views that have both.)
-
-See [Getting Started with FullStory React Native Capture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture) for more info.
 
 ## Fragments
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To activate React Native support you must pass in a `native` plugin option like 
 
 ### React Native with FullStory 
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` and `elementAttribute` options both to `'fsTagName'` to generate better privacy selectors. 
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` and `elementAttribute` options both to [`'fsTagName'`](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture#01GRMBR5FK3R89ZQQ9F3V6Z5RB) to generate better privacy selectors. 
 
 ⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `componentAttribute` and `elementAttribute` set.
 <!-- todo: write up a KB article to walk customers through transitioning to `fsTagName` if they have pre-existing privacy selectors or defined elements; link to it here -->

--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ To activate React Native support you must pass in a `native` plugin option like 
 
 ### React Native with FullStory 
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting the `componentAttribute` and `elementAttribute` options both to [`'fsTagName'`](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture#01GRMBR5FK3R89ZQQ9F3V6Z5RB) to generate better privacy selectors. 
 
-⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `componentAttribute` and `elementAttribute` set.
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `setFSTagName: true` to generate better privacy selectors. (See the [`fsTagName` docs](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) for more info.)
+
+⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `setFSTagName: true`.
 <!-- todo: write up a KB article to walk customers through transitioning to `fsTagName` if they have pre-existing privacy selectors or defined elements; link to it here -->
 
     plugins: [
       '@fullstory/react-native',
       ["@fullstory/annotate-react", {
         native: true,
-        componentAttribute: 'fsTagName',
-        elementAttribute: 'fsTagName',
+        setFSTagName: true,
       }]
     ]
 
@@ -99,7 +99,7 @@ If you would like the plugin to skip the annotation for certain components, use 
 ```javascript
   plugins: [
       [
-        "@fullstory/babel-plugin-annotate-react",
+        "@fullstory/annotate-react",
         {
           ignoreComponents:[
             // each item must be a string array containing three items: file name, component name, element name

--- a/README.md
+++ b/README.md
@@ -54,8 +54,14 @@ When using this library with [FullStory for Mobile Apps](https://www.fullstory.c
 
     plugins: [
       '@fullstory/react-native',
-      ["@fullstory/babel-plugin-annotate-react", { native: true, componentAttribute: 'fsTagName' }]
+      ["@fullstory/babel-plugin-annotate-react", {
+        native: true,
+        componentAttribute: 'fsTagName',
+        elementAttribute: 'fsTagName',
+      }]
     ]
+
+(Note: with this configuration, the component will take precedence over the element for views that have both.)
 
 See [Getting Started with FullStory React Native Capture](https://help.fullstory.com/hc/en-us/articles/360052419133-Getting-Started-with-FullStory-React-Native-Capture) for more info.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 This is a Babel plugin that annotates React components with stable attributes that can be used to search and select using [FullStory](https://www.fullstory.com/). This is most useful when using a React system that generates dynamic names for Components or rearranges elements.
 
-For React on the web the attributes are `data-component`, `data-element`, and `data-source-file`. For React Native the attributes are `dataComponent`, `dataElement`, and `dataSourceFile`.
-These attribute names may be customized by setting the `componentAttribute`, `elementAttribute`, and `sourceFileAttribute` configuration options.
+For React on the web the attributes are `data-component`, `data-element`, and `data-source-file`. For React Native the attributes are `dataComponent`, `dataElement`, and `dataSourceFile`, or [`fsTagName`](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) and `dataSourceFile` with `setFSTagName` enabled.
 
 The component attribute names the `React.Component` and the element attribute names the original native elements like `View` or `Image` or an emitter of DOM elements like `Fragment`.
 
@@ -48,7 +47,7 @@ To activate React Native support you must pass in a `native` plugin option like 
 ### React Native with FullStory 
 
 
-When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `setFSTagName: true` to generate better privacy selectors. (See the [`fsTagName` docs](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) for more info.)
+When using this library with [FullStory for Mobile Apps](https://www.fullstory.com/platform/mobile-apps/), we recommend setting `setFSTagName: true` to generate better privacy selectors by setting [`fsTagName`](https://developer.fullstory.com/mobile/react-native/auto-capture/set-tag-name/) rather than `dataElement` and `dataComponent`.
 
 ⚠️ Important: Existing FullStory privacy selectors and defined elements may need to be updated if the app was previously published without `setFSTagName: true`.
 <!-- todo: write up a KB article to walk customers through transitioning to `fsTagName` if they have pre-existing privacy selectors or defined elements; link to it here -->

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2499,7 +2499,7 @@ it('Bananas incompatible plugin @react-navigation source snapshot matches', () =
   expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
 });
 
-it('Bananas custom attribute names let component override element with setFSTagName', () => {
+it('setFSTagName sets fsTagName on component with its dataComponent value', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2515,3 +2515,57 @@ it('Bananas custom attribute names let component override element with setFSTagN
   );
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithFSTagName);
 });
+
+it('Bananas custom attribute names let component override element with setFSTagName', () => {
+  const BananasInputCustomFSTagName = `import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return <Image source={pic} style={{ width: 193, height: 110, marginTop: 10 }} fsClass="test-class" fsTagName="CustomTagName" />;
+  }
+}`;
+
+  const BananasOutputCustomFSTagName = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      fsTagName: \\"CustomTagName\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
+  const { code } = babel.transform(
+    BananasInputCustomFSTagName,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, {
+          native: true,
+          setFSTagName: true,
+        }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasOutputCustomFSTagName);
+});

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1157,6 +1157,32 @@ class Bananas extends Component {
 }"
 `;
 
+const BananasStandardOutputWithCustomAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      testElement: \\"Image\\",
+      testComponent: \\"Bananas\\",
+      testSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
 it('unknown-element snapshot matches', () => {
   const { code } = babel.transform(
     `import React, { Component } from 'react';
@@ -2472,4 +2498,23 @@ it('Bananas incompatible plugin @react-navigation source snapshot matches', () =
     },
   );
   expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
+});
+
+it('Bananas custom attribute names matches', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, {
+          native: true,
+          componentAttribute: 'testComponent',
+          elementAttribute: 'testElement',
+          sourceFileAttribute: 'testSourceFile'
+        }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithCustomAttributes);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1157,33 +1157,7 @@ class Bananas extends Component {
 }"
 `;
 
-const BananasStandardOutputWithCustomAttributes = `
-"import React, { Component } from 'react';
-import { Image } from 'react-native';
-
-class Bananas extends Component {
-  render() {
-    let pic = {
-      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
-    };
-    return /*#__PURE__*/React.createElement(Image, {
-      source: pic,
-      style: {
-        width: 193,
-        height: 110,
-        marginTop: 10
-      },
-      fsClass: \\"test-class\\",
-      testElement: \\"Image\\",
-      testComponent: \\"Bananas\\",
-      testSourceFile: \\"filename-test.js\\"
-    });
-  }
-
-}"
-`;
-
-const BananasStandardOutputWithFSAttributes = `
+const BananasStandardOutputWithFSTagName = `
 "import React, { Component } from 'react';
 import { Image } from 'react-native';
 
@@ -1201,7 +1175,7 @@ class Bananas extends Component {
       },
       fsClass: \\"test-class\\",
       fsTagName: \\"Bananas\\",
-      testSourceFile: \\"filename-test.js\\"
+      dataSourceFile: \\"filename-test.js\\"
     });
   }
 
@@ -2525,7 +2499,7 @@ it('Bananas incompatible plugin @react-navigation source snapshot matches', () =
   expect(code).toMatchInlineSnapshot(BananasStandardOutputNoAttributes);
 });
 
-it('Bananas custom attribute names matches', () => {
+it('Bananas custom attribute names let component override element with setFSTagName', () => {
   const { code } = babel.transform(
     BananasStandardInput,
     {
@@ -2534,31 +2508,10 @@ it('Bananas custom attribute names matches', () => {
       plugins: [
         [plugin, {
           native: true,
-          componentAttribute: 'testComponent',
-          elementAttribute: 'testElement',
-          sourceFileAttribute: 'testSourceFile'
+          setFSTagName: true,
         }]
       ]
     },
   );
-  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithCustomAttributes);
-});
-
-it('Bananas custom attribute names let component override element', () => {
-  const { code } = babel.transform(
-    BananasStandardInput,
-    {
-      filename: "filename-test.js",
-      presets: ["@babel/preset-react"],
-      plugins: [
-        [plugin, {
-          native: true,
-          componentAttribute: 'fsTagName',
-          elementAttribute: 'fsTagName',
-          sourceFileAttribute: 'testSourceFile'
-        }]
-      ]
-    },
-  );
-  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithFSAttributes);
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithFSTagName);
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -1183,6 +1183,31 @@ class Bananas extends Component {
 }"
 `;
 
+const BananasStandardOutputWithFSAttributes = `
+"import React, { Component } from 'react';
+import { Image } from 'react-native';
+
+class Bananas extends Component {
+  render() {
+    let pic = {
+      uri: 'https://upload.wikimedia.org/wikipedia/commons/d/de/Bananavarieties.jpg'
+    };
+    return /*#__PURE__*/React.createElement(Image, {
+      source: pic,
+      style: {
+        width: 193,
+        height: 110,
+        marginTop: 10
+      },
+      fsClass: \\"test-class\\",
+      fsTagName: \\"Bananas\\",
+      testSourceFile: \\"filename-test.js\\"
+    });
+  }
+
+}"
+`;
+
 it('unknown-element snapshot matches', () => {
   const { code } = babel.transform(
     `import React, { Component } from 'react';
@@ -2517,4 +2542,23 @@ it('Bananas custom attribute names matches', () => {
     },
   );
   expect(code).toMatchInlineSnapshot(BananasStandardOutputWithCustomAttributes);
+});
+
+it('Bananas custom attribute names let component override element', () => {
+  const { code } = babel.transform(
+    BananasStandardInput,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [
+        [plugin, {
+          native: true,
+          componentAttribute: 'fsTagName',
+          elementAttribute: 'fsTagName',
+          sourceFileAttribute: 'testSourceFile'
+        }]
+      ]
+    },
+  );
+  expect(code).toMatchInlineSnapshot(BananasStandardOutputWithFSAttributes);
 });

--- a/index.js
+++ b/index.js
@@ -157,10 +157,12 @@ function isKnownIncompatiblePluginFromState(state) {
 }
 
 function attributeNamesFromState(state) {
-  if (state.opts[nativeOptionName] === true) {
-    return [nativeComponentName, nativeElementName, nativeSourceFileName]
-  }
-  return [webComponentName, webElementName, webSourceFileName]
+  const native = state.opts.native === true;
+  return [
+    state.opts.componentAttribute || native ? nativeComponentName : webComponentName,
+    state.opts.elementAttribute || native ? nativeElementName : webElementName,
+    state.opts.sourceFileAttribute || native ? nativeSourceFileName : webSourceFileName
+  ]
 }
 
 function isReactFragment(openingElement) {

--- a/index.js
+++ b/index.js
@@ -159,9 +159,9 @@ function isKnownIncompatiblePluginFromState(state) {
 function attributeNamesFromState(state) {
   const native = state.opts.native === true;
   return [
-    state.opts.componentAttribute || native ? nativeComponentName : webComponentName,
-    state.opts.elementAttribute || native ? nativeElementName : webElementName,
-    state.opts.sourceFileAttribute || native ? nativeSourceFileName : webSourceFileName
+    state.opts.componentAttribute || (native ? nativeComponentName : webComponentName),
+    state.opts.elementAttribute || (native ? nativeElementName : webElementName),
+    state.opts.sourceFileAttribute || (native ? nativeSourceFileName : webSourceFileName)
   ]
 }
 

--- a/index.js
+++ b/index.js
@@ -215,7 +215,9 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
   // Add a stable attribute for the element name but only for non-DOM names
   if (
     !ignoredComponentFromOptions &&
-    !hasNodeNamed(openingElement, componentAttributeName)
+    !hasNodeNamed(openingElement, componentAttributeName) &&
+    // if componentAttributeName and elementAttributeName are set to the same thing (e.g. fsTagName), then only set the element attribute when we don't have a component attribute
+    (componentAttributeName !== elementAttributeName) || !componentName
   ) {
     if (defaultIgnoredElements.includes(elementName)) {
       ignoredElement = true

--- a/index.js
+++ b/index.js
@@ -160,12 +160,8 @@ function isKnownIncompatiblePluginFromState(state) {
 }
 
 function attributeNamesFromState(state) {
-  const { native, setFSTagName } = state.opts;
-  if (setFSTagName && !native) {
-    throw new Error('`setFSTagName: true` is invalid unless `native: true` is also set in the configuration for @fullstory/babel-plugin-annotate-react')
-  }
-  if (native) {
-    if (setFSTagName) {
+  if (state.opts.native) {
+    if (state.opts.setFSTagName) {
       return [fsTagName, fsTagName, nativeSourceFileName];
     } else {
       return [nativeComponentName, nativeElementName, nativeSourceFileName];

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const nativeComponentName = 'dataComponent';
 const nativeElementName = 'dataElement';
 const nativeSourceFileName = 'dataSourceFile';
 
-const nativeOptionName = 'native';
 const annotateFragmentsOptionName = 'annotate-fragments';
 const ignoreComponentsOptionName = 'ignoreComponents';
 

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ function applyAttributes(t, openingElement, componentName, sourceFileName, attri
     !ignoredComponentFromOptions &&
     !hasNodeNamed(openingElement, componentAttributeName) &&
     // if componentAttributeName and elementAttributeName are set to the same thing (e.g. fsTagName), then only set the element attribute when we don't have a component attribute
-    (componentAttributeName !== elementAttributeName) || !componentName
+    ((componentAttributeName !== elementAttributeName) || !componentName)
   ) {
     if (defaultIgnoredElements.includes(elementName)) {
       ignoredElement = true


### PR DESCRIPTION
This adds a new `setFSTagName` boolean option that sets the `fsTagName` attribute instead of `componentAttribute` and `elementAttribute` (e.g. `MyCoolComponent` instead of `RCTView` or `Text` instead of `RCTTextView`).

This allows us to generate better privacy selectors with less noise.

Ticket: https://fullstory.atlassian.net/browse/MOEN-374

We'll also want to coordinate with the KB team on updating the getting started guide after this change is released.