### PR TITLE
exclude navigation libaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ const knownIncompatiblePlugins = [
   'react-native-testfairy',
   // This module checks for unexpected property keys and throws an exception.
   '@react-navigation',
+  // Annotations on this module may cause unexpected UI behavior. VAL-9242
+  'react-native-navigation',
+  // This module is incompatible with our ref rewrites on iOS.
+  'expo-router',
   // The victory* modules use `dataComponent` and we get a collision.
   'victory',
   'victory-area',


### PR DESCRIPTION
Excluding two navigation libraries from annotation. Components from navigation libraries exist across screens and shared amongst the top level of all selectors, so it should have minimal effect on usability if eliminated. 

- react-native-navigation: https://fullstory.atlassian.net/browse/VAL-9242 this customer has shown that our annotate plugin is the cause of the unexpected UI behavior. Instead of trying to jot down which component/element to add to the `ignoreComponents` list, we should just exclude the entire navigation library from annotation.
- expo-router: https://fullstory.atlassian.net/browse/WECA-1331 https://fullstory.atlassian.net/browse/WECA-1330 expo-router is passing refs to components that doesn't accept them. Our ref rewrite code will throw warnings to customers since expo-router components are relying on `refs` to be `null`. As for the invalid prop error, expo-router is passing fragments in a way that our current plugin cannot detect them as fragments. This is something we can improve on detecting in the future, but it likely cannot be 100% bullet-proof.