### PR TITLE
React compiler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,39 @@ If you would like the plugin to attempt to annotate the first HTML element creat
       ["@fullstory/babel-plugin-annotate-react", { "annotate-fragments": true }]
     ]
 
+## React Compiler
+
+If your project uses the [React Compiler](https://react.dev/learn/react-compiler), enable the `reactCompiler` option:
+
+```javascript
+plugins: [
+  ["@fullstory/babel-plugin-annotate-react", { reactCompiler: true }]
+]
+```
+
+The React Compiler optimizes function components by extracting JSX subtrees out of `return` statements into intermediate cached variables. This means a compiled component may look like:
+
+```javascript
+// Before React Compiler
+function MyComponent() {
+  return <div className="foo">Hello</div>;
+}
+
+// After React Compiler (simplified)
+function MyComponent() {
+  let t0;
+  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <div className="foo">Hello</div>;
+    $[0] = t0;
+  }
+  return t0;
+}
+```
+
+Without `reactCompiler: true`, the plugin would see a non-JSX `return` statement and skip the component entirely, producing no annotations. With the option enabled, the plugin traverses the entire function body to find and annotate all JSX nodes, regardless of where they appear.
+
+⚠️ **Important:** Because the React Compiler restructures how JSX is emitted, enabling `reactCompiler: true` may change which JSX nodes get annotated. Selectors and named elements previously defined in Fullstory are not guaranteed to match after enabling this option. Review your existing segments, metrics, and defined elements after activating this setting.
+
 ## Ignoring Components
 
 If you would like the plugin to skip the annotation for certain components, use the `ignoreComponents` option:

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -530,6 +530,7 @@ export default componentName;"
 
 exports[`react-compiler-deeply-extracted-jsx snapshot matches 1`] = `
 "import React from 'react';
+
 const App = () => {
   let t0, t1, t2, t3, t4;
   const t5 = /*#__PURE__*/React.createElement(View, {
@@ -572,28 +573,35 @@ const App = () => {
   }, t1, t2);
   return t0;
 };
+
 export default App;"
 `;
 
 exports[`react-compiler-extracted-jsx snapshot matches 1`] = `
 "import React from 'react';
+
 function MyComponent() {
   let t0;
+
   if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
     t0 = /*#__PURE__*/React.createElement(\\"div\\", {
       \\"data-component\\": \\"MyComponent\\",
       \\"data-source-file\\": \\"filename-test.js\\"
     }, \\"Hello world\\");
   }
+
   return t0;
 }
+
 export default MyComponent;"
 `;
 
 exports[`react-compiler-inner-function-jsx-not-annotated-with-outer-name 1`] = `
 "import React from 'react';
+
 const App = () => {
   let t0;
+
   if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
     const renderItem = item => /*#__PURE__*/React.createElement(View, {
       dataElement: \\"View\\",
@@ -603,6 +611,7 @@ const App = () => {
       dataElement: \\"Text\\",
       dataSourceFile: \\"filename-test.js\\"
     }, item.name));
+
     t0 = /*#__PURE__*/React.createElement(FlatList, {
       renderItem: renderItem,
       dataElement: \\"FlatList\\",
@@ -610,15 +619,19 @@ const App = () => {
       dataSourceFile: \\"filename-test.js\\"
     });
   }
+
   return t0;
 };
+
 export default App;"
 `;
 
 exports[`react-compiler-multiple-extracted-jsx snapshot matches 1`] = `
 "import React from 'react';
+
 const App = () => {
   let t0, t1, t2;
+
   if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
     t1 = /*#__PURE__*/React.createElement(Pressable, {
       onPress: onPress,
@@ -643,8 +656,10 @@ const App = () => {
       dataSourceFile: \\"filename-test.js\\"
     }, t1, t2);
   }
+
   return t0;
 };
+
 export default App;"
 `;
 

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -281,6 +281,27 @@ class componentName extends Component {
 export default componentName;"
 `;
 
+exports[`hoc-inner-class-component snapshot matches 1`] = `
+"import React, { Component } from 'react';
+
+function createAnimatedComponent(WrappedComponent) {
+  class AnimatedComponent extends Component {
+    render() {
+      return /*#__PURE__*/React.createElement(WrappedComponent, {
+        \\"data-element\\": \\"WrappedComponent\\",
+        \\"data-component\\": \\"AnimatedComponent\\",
+        \\"data-source-file\\": \\"filename-test.js\\"
+      });
+    }
+
+  }
+
+  return AnimatedComponent;
+}
+
+export default createAnimatedComponent;"
+`;
+
 exports[`nonJSX snapshot matches 1`] = `
 "import React, { Component } from 'react';
 
@@ -505,6 +526,126 @@ const componentName = () => {
 };
 
 export default componentName;"
+`;
+
+exports[`react-compiler-deeply-extracted-jsx snapshot matches 1`] = `
+"import React from 'react';
+const App = () => {
+  let t0, t1, t2, t3, t4;
+  const t5 = /*#__PURE__*/React.createElement(View, {
+    dataElement: \\"View\\",
+    dataComponent: \\"App\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"Static\\"));
+  t3 = /*#__PURE__*/React.createElement(View, {
+    dataElement: \\"View\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    fsClass: isMasked ? 'fs-mask' : 'fs-unmask',
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"Dynamic\\"));
+  t1 = /*#__PURE__*/React.createElement(Pressable, {
+    onPress: onPress,
+    dataElement: \\"Pressable\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, t5);
+  t4 = /*#__PURE__*/React.createElement(View, {
+    dataElement: \\"View\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, /*#__PURE__*/React.createElement(Text, {
+    fsClass: isMasked ? 'fs-mask' : 'fs-unmask',
+    dataElement: \\"Text\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, \\"Dynamic 2\\"));
+  t2 = /*#__PURE__*/React.createElement(Pressable, {
+    onPress: onPress,
+    dataElement: \\"Pressable\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, t3);
+  t0 = /*#__PURE__*/React.createElement(ScrollView, {
+    dataElement: \\"ScrollView\\",
+    dataSourceFile: \\"filename-test.js\\"
+  }, t1, t2);
+  return t0;
+};
+export default App;"
+`;
+
+exports[`react-compiler-extracted-jsx snapshot matches 1`] = `
+"import React from 'react';
+function MyComponent() {
+  let t0;
+  if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
+    t0 = /*#__PURE__*/React.createElement(\\"div\\", {
+      \\"data-component\\": \\"MyComponent\\",
+      \\"data-source-file\\": \\"filename-test.js\\"
+    }, \\"Hello world\\");
+  }
+  return t0;
+}
+export default MyComponent;"
+`;
+
+exports[`react-compiler-inner-function-jsx-not-annotated-with-outer-name 1`] = `
+"import React from 'react';
+const App = () => {
+  let t0;
+  if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
+    const renderItem = item => /*#__PURE__*/React.createElement(View, {
+      dataElement: \\"View\\",
+      dataComponent: \\"renderItem\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(Text, {
+      dataElement: \\"Text\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, item.name));
+    t0 = /*#__PURE__*/React.createElement(FlatList, {
+      renderItem: renderItem,
+      dataElement: \\"FlatList\\",
+      dataComponent: \\"App\\",
+      dataSourceFile: \\"filename-test.js\\"
+    });
+  }
+  return t0;
+};
+export default App;"
+`;
+
+exports[`react-compiler-multiple-extracted-jsx snapshot matches 1`] = `
+"import React from 'react';
+const App = () => {
+  let t0, t1, t2;
+  if (t0 === Symbol.for(\\"react.memo_cache_sentinel\\")) {
+    t1 = /*#__PURE__*/React.createElement(Pressable, {
+      onPress: onPress,
+      fsTagName: \\"FS_Pressable\\",
+      dataElement: \\"Pressable\\",
+      dataComponent: \\"App\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(View, {
+      dataElement: \\"View\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }));
+    t2 = /*#__PURE__*/React.createElement(Pressable, {
+      onPress: onPress,
+      dataElement: \\"Pressable\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, /*#__PURE__*/React.createElement(View, {
+      dataElement: \\"View\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }));
+    t0 = /*#__PURE__*/React.createElement(ScrollView, {
+      dataElement: \\"ScrollView\\",
+      dataSourceFile: \\"filename-test.js\\"
+    }, t1, t2);
+  }
+  return t0;
+};
+export default App;"
 `;
 
 exports[`tags snapshot matches 1`] = `

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -2569,3 +2569,142 @@ class Bananas extends Component {
   );
   expect(code).toMatchInlineSnapshot(BananasOutputCustomFSTagName);
 });
+
+it('react-compiler-extracted-jsx snapshot matches', () => {
+  // Simulates output from React Compiler, which extracts JSX out of the return
+  // statement into a cached variable inside a conditional block.
+  const { code } = babel.transform(
+    `import React from 'react';
+
+function MyComponent() {
+  let t0;
+  if (t0 === Symbol.for("react.memo_cache_sentinel")) {
+    t0 = <div>Hello world</div>;
+  }
+  return t0;
+}
+
+export default MyComponent;
+`,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [[plugin, { reactCompiler: true }]],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('react-compiler-multiple-extracted-jsx snapshot matches', () => {
+  // Simulates React Compiler output where multiple JSX subtrees are extracted into
+  // separate cached variables (e.g. two sibling Pressables in the same component).
+  // Each extracted JSX element should receive dataElement and dataSourceFile attributes.
+  const { code } = babel.transform(
+    `import React from 'react';
+
+const App = () => {
+  let t0, t1, t2;
+  if (t0 === Symbol.for("react.memo_cache_sentinel")) {
+    t1 = <Pressable onPress={onPress} fsTagName="FS_Pressable"><View /></Pressable>;
+    t2 = <Pressable onPress={onPress}><View /></Pressable>;
+    t0 = <ScrollView>{t1}{t2}</ScrollView>;
+  }
+  return t0;
+};
+
+export default App;
+`,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [[plugin, { native: true, reactCompiler: true }]],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('react-compiler-deeply-extracted-jsx snapshot matches', () => {
+  // Simulates React Compiler output where children are ALSO extracted into separate
+  // variables (not just the top-level elements). This matches the real-world pattern
+  // where e.g. a View inside a Pressable is extracted because it has a dynamic child.
+  // The extracted View should still receive dataElement and dataSourceFile.
+  const { code } = babel.transform(
+    `import React from 'react';
+
+const App = () => {
+  let t0, t1, t2, t3, t4;
+  const t5 = <View><Text>Static</Text></View>;
+  t3 = <View><Text fsClass={isMasked ? 'fs-mask' : 'fs-unmask'}>Dynamic</Text></View>;
+  t1 = <Pressable onPress={onPress}>{t5}</Pressable>;
+  t4 = <View><Text fsClass={isMasked ? 'fs-mask' : 'fs-unmask'}>Dynamic 2</Text></View>;
+  t2 = <Pressable onPress={onPress}>{t3}</Pressable>;
+  t0 = <ScrollView>{t1}{t2}</ScrollView>;
+  return t0;
+};
+
+export default App;
+`,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [[plugin, { native: true, reactCompiler: true }]],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});
+
+it('react-compiler-inner-function-jsx-not-annotated-with-outer-name', () => {
+  // JSX inside an inner arrow function (e.g. a renderItem callback) should not
+  // receive the outer component's name — the traversal must not descend into
+  // inner functions.
+  const { code } = babel.transform(
+    `import React from 'react';
+
+const App = () => {
+  let t0;
+  if (t0 === Symbol.for("react.memo_cache_sentinel")) {
+    const renderItem = (item) => <View><Text>{item.name}</Text></View>;
+    t0 = <FlatList renderItem={renderItem} />;
+  }
+  return t0;
+};
+
+export default App;
+`,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [[plugin, { native: true, reactCompiler: true }]],
+    },
+  );
+  // The FlatList gets dataComponent/dataElement/dataSourceFile.
+  // The View inside renderItem gets dataElement/dataSourceFile but NOT dataComponent.
+  expect(code).toMatchSnapshot();
+});
+
+it('hoc-inner-class-component snapshot matches', () => {
+  // An outer factory function (HOC) that defines and returns an inner class
+  // component. The inner component's JSX should be annotated with the inner
+  // component's name, not the outer factory function's name.
+  const { code } = babel.transform(
+    `import React, { Component } from 'react';
+
+function createAnimatedComponent(WrappedComponent) {
+  class AnimatedComponent extends Component {
+    render() {
+      return <WrappedComponent />;
+    }
+  }
+  return AnimatedComponent;
+}
+
+export default createAnimatedComponent;
+`,
+    {
+      filename: "filename-test.js",
+      presets: ["@babel/preset-react"],
+      plugins: [[plugin, { reactCompiler: true }]],
+    },
+  );
+  expect(code).toMatchSnapshot();
+});

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const fsTagName = 'fsTagName'
 
 const annotateFragmentsOptionName = 'annotate-fragments';
 const ignoreComponentsOptionName = 'ignoreComponents';
+const reactCompilerOptionName = 'reactCompiler';
 
 const knownIncompatiblePlugins = [
   // This module might be causing an issue preventing clicks. For safety, we won't run on this module.
@@ -70,6 +71,8 @@ module.exports = function ({ types: t }) {
           path,
           path.node.id.name,
           sourceFileNameFromState(state),
+          state.opts[reactCompilerOptionName] === true,
+          fullSourceFileNameFromState(state),
           attributeNamesFromState(state),
           this.ignoreComponentsFromOption,
         )
@@ -83,6 +86,8 @@ module.exports = function ({ types: t }) {
           path,
           path.parent.id.name,
           sourceFileNameFromState(state),
+          state.opts[reactCompilerOptionName] === true,
+          fullSourceFileNameFromState(state),
           attributeNamesFromState(state),
           this.ignoreComponentsFromOption,
         )
@@ -295,7 +300,7 @@ function processJSX(annotateFragments, t, jsxNode, componentName, sourceFileName
   }
 }
 
-function functionBodyPushAttributes(annotateFragments, t, path, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption) {
+function functionBodyPushAttributes(annotateFragments, t, path, componentName, sourceFileName, reactCompiler, fullSourceFileName, attributeNames, ignoreComponentsFromOption) {
   let jsxNode = null
   const functionBody = path.get('body').get('body')
   if (functionBody.parent &&
@@ -317,10 +322,49 @@ function functionBodyPushAttributes(annotateFragments, t, path, componentName, s
     if (!arg) {
       return
     }
-    if (!arg.isJSXFragment() && !arg.isJSXElement()) {
+    if (!arg.isJSXFragment() && !arg.isJSXElement() && !reactCompiler) {
       return
+    } else {
+      jsxNode = arg
     }
-    jsxNode = arg
+
+    // If no direct JSX return (e.g. React compiler extracted JSX into variables/conditionals),
+    // traverse the entire function body to find all top-level JSX elements or fragments.
+    // Only enabled when reactCompiler option is true, and skipped for node_modules to avoid
+    // annotating library internals that would shadow annotations from app code.
+    const isNodeModule = fullSourceFileName && (
+      fullSourceFileName.includes('/node_modules/') ||
+      fullSourceFileName.includes('\\node_modules\\')
+    )
+    if (!jsxNode && reactCompiler && !isNodeModule) {
+      // Collect all top-level JSX nodes in the function body (React Compiler may extract
+      // multiple JSX subtrees into separate cached variables). We annotate each one:
+      // the first gets componentName (it's the root), the rest get null (they're children).
+      const allJsxNodes = []
+      path.traverse({
+        // Do not descend into inner functions or classes — their JSX belongs to them, not this component
+        FunctionDeclaration(innerPath) { innerPath.skip() },
+        FunctionExpression(innerPath) { innerPath.skip() },
+        ArrowFunctionExpression(innerPath) { innerPath.skip() },
+        ClassDeclaration(innerPath) { innerPath.skip() },
+        ClassExpression(innerPath) { innerPath.skip() },
+        JSXElement(innerPath) {
+          allJsxNodes.push(innerPath)
+          innerPath.skip()
+        },
+        JSXFragment(innerPath) {
+          allJsxNodes.push(innerPath)
+          innerPath.skip()
+        },
+      })
+      if (allJsxNodes.length > 0) {
+        jsxNode = allJsxNodes[0]
+        // Annotate all additional extracted JSX nodes as children (no componentName)
+        for (let i = 1; i < allJsxNodes.length; i++) {
+          processJSX(annotateFragments, t, allJsxNodes[i], null, sourceFileName, attributeNames, ignoreComponentsFromOption)
+        }
+      }
+    }
   }
   if (!jsxNode) return
   processJSX(annotateFragments, t, jsxNode, componentName, sourceFileName, attributeNames, ignoreComponentsFromOption)

--- a/index.js
+++ b/index.js
@@ -322,8 +322,8 @@ function functionBodyPushAttributes(annotateFragments, t, path, componentName, s
     if (!arg) {
       return
     }
-    if (!arg.isJSXFragment() && !arg.isJSXElement() && !reactCompiler) {
-      return
+    if (!arg.isJSXFragment() && !arg.isJSXElement()) {
+      if (!reactCompiler) return
     } else {
       jsxNode = arg
     }


### PR DESCRIPTION
### Add reactCompiler option for React Compiler compatibility

The [React Compiler](https://react.dev/learn/react-compiler) is a build-time optimization that introduces automatic memoization for hooks and components. As part of this optimization, it restructures how JSX is emitted — extracting JSX subtrees out of return statements into intermediate cached variables. This causes the annotation plugin to skip components entirely, since it expects JSX to appear directly in a return statement.

This PR adds a new opt-in reactCompiler configuration option that preserves consistent annotation behavior before and after enabling the React Compiler. When set to true, the plugin traverses the full function body to locate and annotate JSX nodes regardless of where they appear after compilation.

The feature is **opt-in** to minimize the risk of disrupting existing named elements and selectors in FullStory for projects that have not yet adopted the React Compiler.

**With react optimizer**
iOS: https://app.staging.fullstory.com/ui/3RWN/session/5190210412904448:484062130949806242
Android: https://app.staging.fullstory.com/ui/KWH/session/3810073241491698255:330215251229855706

**Without react optimizer (old behavior)** 
iOS: https://app.staging.fullstory.com/ui/3RWN/session/5190210412904448:2010617202285750036
Android: https://app.staging.fullstory.com/ui/KWH/session/3810073241491698255:2423042870225285268

I have verified that selectors are stable given the screens I've tested on. 