### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A Babel plugin that annotates React components, making them easier to target with FullStory search",
   "main": "index.js",
   "homepage": "https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react",
+  "bugs": {
+    "url": "https://github.com/fullstorydev/fullstory-babel-plugin-annotate-react/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fullstory-babel-plugin-annotate-react.git"


### PR DESCRIPTION
## Summary

Adds the package `bugs.url` metadata field so npm consumers can discover the GitHub issue tracker from the published package metadata.

## Validation

- Confirmed the currently published package metadata for `@fullstory/babel-plugin-annotate-react@2.4.0` has no `bugs` field.
- Ran a package metadata assertion for the new `bugs.url`.
- Ran `npm pack --dry-run --json --ignore-scripts`.
- Inspected the actual packed tarball `package/package.json` and confirmed the new `bugs.url` is included.
- Ran `npm install --ignore-scripts --no-audit --no-fund`.
- Ran `npm test -- --runInBand`: 1 suite passed, 70 tests passed, 70 snapshots passed.
- Ran `git diff --check`.

Note: the test run emitted the existing Browserslist/caniuse-lite freshness warning only.
